### PR TITLE
Add post_org_repos

### DIFF
--- a/src/repositories.rs
+++ b/src/repositories.rs
@@ -11,6 +11,14 @@ pub trait Repos {
     /// ### Request Type:
     /// `POST`
     /// ### Endpoint:
+    /// /orgs/:org/repos
+    /// ### Description
+    /// Creates a new repo in the specified organization for the authenticated user and returns the new `Repo`s stats
+    fn post_org_repos(&self, organization: String, repo: RepoCreate) -> Result<Repo>;
+
+    /// ### Request Type:
+    /// `POST`
+    /// ### Endpoint:
     /// /user/repos
     /// ### Description
     /// Creates a new repo for the authenticated user and returns the new `Repo`s stats
@@ -19,6 +27,20 @@ pub trait Repos {
 
 /// Implementation of the Repos trait for the `Client`
 impl Repos for Client {
+    /// ### Request Type:
+    /// `POST`
+    /// ### Endpoint:
+    /// /orgs/:org/repos
+    /// ### Description
+    /// Creates a new repo in the specified organization for the authenticated user and returns the new `Repo`s stats
+    fn post_org_repos(&self, organization: String, repo: RepoCreate) -> Result<Repo> {
+        let url = format!("https://api.github.com/orgs/{}/repos", organization);
+        let res = try!(post(&url,
+                            self.headers.clone(),
+                            try!(serde_json::to_string(&repo))));
+        try_serde!(serde_json::from_str(&res))
+    }
+
     /// ### Request Type:
     /// `POST`
     /// ### Endpoint:


### PR DESCRIPTION
Add support for `POST /orgs/:org/repos`
