### PR TITLE
Update github-rs to use serde procedural macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 Cargo.lock
+tests/auth_token

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: true
 language: rust
 rust:
-  - nightly-2016-08-12
+  - nightly
 addons:
   apt:
     packages:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,15 @@ documentation = "https://mgattozzi.github.io/github-rs"
 
 [dependencies]
 hyper = "0.9.10"
-serde = "0.7.4"
-serde_json = "0.7.4"
-serde_macros = "0.7.4"
+serde = "^0.8.0"
+serde_json = "^0.8.0"
+serde_derive = "^0.8.0"
 solicit = "0.4.4"
 url = "1.1.1"
 
 [dependencies.clippy]
 optional = true
-version = "0.0.83"
+version = "*"
 
 [features]
 default = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -136,7 +136,6 @@ impl From<serdeErr::Error> for GithubError {
         match serde {
             Syntax(x, y, z) => JsonParsingSyntax(x, y, z),
             Io(err) => JsonParsingIo(err),
-            FromUtf8(err) => JsonParsingFromUtf8(err),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,22 @@
 //! Library to used to access the Github API with Rust
-#![feature(custom_derive, plugin)]
+#![feature(custom_derive, proc_macro)]
 #![cfg_attr(feature = "dev", plugin(clippy))]
-#![plugin(serde_macros)]
 // This allows for better enforc
 // unstable_features add one day when custom derive is stableed style and project features
 #![deny(missing_docs, missing_debug_implementations, missing_copy_implementations,
         trivial_casts, trivial_numeric_casts, unsafe_code, unused_import_braces,
         unused_qualifications)]
+
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+
+// Only here for error handling with hyper
+extern crate solicit;
+extern crate url;
+
 // This has to be here so the macros are available everywhere
 #[macro_use]
 mod macros;
@@ -31,10 +41,3 @@ mod search;
 mod types;
 mod users;
 
-extern crate hyper;
-extern crate serde;
-extern crate serde_json;
-
-// Only here for error handling with hyper
-extern crate solicit;
-extern crate url;


### PR DESCRIPTION
In order to be stablized macros 1.1 is being tested and eventually
deployed so we can do custom derive. This was implemented in serde
0.8.0. This commit updates github-rs so that it uses the proper
libraries and moving it over to just work on nightly.