### PR TITLE
Add media type support and cleanup imports

### DIFF
--- a/src/activity.rs
+++ b/src/activity.rs
@@ -104,7 +104,7 @@ impl Activity for Client {
     /// Returns a vector of recent `Event`s from the API
     fn get_events(&self) -> Result<Vec<Event>> {
         let url = "https://api.github.com/events";
-        let data = get(url, self.headers.clone())?;
+        let data = get(url, self.get_headers().clone())?;
 
         // If the auth token is wrong we want this to panic.
         try_serde!(serde_json::from_str(&data))
@@ -123,7 +123,7 @@ impl Activity for Client {
         url.push('/');
         url.push_str(repo);
         url.push_str("/events");
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
 
         try_serde!(serde_json::from_str(&data))
     }
@@ -140,7 +140,7 @@ impl Activity for Client {
         url.push('/');
         url.push_str(repo);
         url.push_str("/issues/events");
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
 
         try_serde!(serde_json::from_str(&data))
     }
@@ -157,7 +157,7 @@ impl Activity for Client {
         url.push('/');
         url.push_str(repo);
         url.push_str("/events");
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
 
         try_serde!(serde_json::from_str(&data))
     }
@@ -172,7 +172,7 @@ impl Activity for Client {
         let mut url = String::from("https://api.github.com/orgs/");
         url.push_str(org);
         url.push_str("/events");
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
 
         try_serde!(serde_json::from_str(&data))
 
@@ -189,7 +189,7 @@ impl Activity for Client {
         let mut url = String::from("https://api.github.com/users/");
         url.push_str(username);
         url.push_str("/received_events");
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
 
         try_serde!(serde_json::from_str(&data))
 
@@ -205,7 +205,7 @@ impl Activity for Client {
         let mut url = String::from("https://api.github.com/users/");
         url.push_str(username);
         url.push_str("/received_events/public");
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
 
         try_serde!(serde_json::from_str(&data))
     }
@@ -221,7 +221,7 @@ impl Activity for Client {
         let mut url = String::from("https://api.github.com/users/");
         url.push_str(username);
         url.push_str("/events");
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
 
         try_serde!(serde_json::from_str(&data))
     }
@@ -237,7 +237,7 @@ impl Activity for Client {
         let mut url = String::from("https://api.github.com/users/");
         url.push_str(username);
         url.push_str("/events/public");
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
 
         try_serde!(serde_json::from_str(&data))
     }
@@ -254,7 +254,7 @@ impl Activity for Client {
         url.push_str(username);
         url.push_str("/events/orgs/");
         url.push_str(org);
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
 
         try_serde!(serde_json::from_str(&data))
 

--- a/src/git_data.rs
+++ b/src/git_data.rs
@@ -73,7 +73,7 @@ impl GitData for Client {
     //             "https://api.github.com/repos/{}/{}/git/blobs/{}",
     //             owner, repo, sha
     //         );
-    //     let data = get(&url, self.headers.clone())?;
+    //     let data = get(&url, self.get_headers().clone())?;
     //     try_serde!(serde_json::from_str(&data))
     // }
 
@@ -83,7 +83,7 @@ impl GitData for Client {
                 "https://api.github.com/repos/{}/{}/git/commits/{}",
                 owner, repo, sha
             );
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&data))
     }
 
@@ -93,7 +93,7 @@ impl GitData for Client {
                 "https://api.github.com/repos/{}/{}/git/refs/{}",
                 owner, repo, _ref
             );
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
 
         if data.contains("Not Found") {
             Err(GithubError::Github404)
@@ -108,7 +108,7 @@ impl GitData for Client {
                 "https://api.github.com/repos/{}/{}/git/refs/{}",
                 owner, repo, _ref
             );
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
         if data.contains("Not Found") {
             Err(GithubError::Github404)
         } else {
@@ -122,7 +122,7 @@ impl GitData for Client {
                 "https://api.github.com/repos/{}/{}/git/refs",
                 owner, repo
             );
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
         if data.contains("Not Found") {
             Err(GithubError::Github404)
         } else {

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,7 +1,5 @@
 //! Structs related to JSON serialization/deserialization
 #![allow(missing_docs)]
-extern crate serde;
-extern crate serde_json;
 
 /// Information related to a user on Github is stored in this struct.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/src/miscellaneous.rs
+++ b/src/miscellaneous.rs
@@ -1,13 +1,10 @@
 //! Trait definition related to Miscellaneous items on Github
-
-extern crate hyper;
-extern crate serde_json;
-
 use json::{GitIgnore, RateLimit, Meta, Markdown};
 use requests::*;
 use error::*;
 use types::HTML;
 use github::Client;
+use serde_json;
 
 /// Trait used to specify function hearders for endpoints grouped under Miscellaneous in the Github
 /// API specification
@@ -79,7 +76,7 @@ impl Misc for Client {
     /// Returns a `Meta` struct which contains information about the Github service
     fn get_meta(&self) -> Result<Meta> {
         let url = "https://api.github.com/meta";
-        let data = get(url, self.headers.clone())?;
+        let data = get(url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&data))
     }
 
@@ -92,7 +89,7 @@ impl Misc for Client {
     /// Note hiting this endpoint with a request does not count against that limit.
     fn get_rate_limit(&self) -> Result<RateLimit> {
         let url = "https://api.github.com/rate_limit";
-        let data = get(url, self.headers.clone())?;
+        let data = get(url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&data))
     }
 
@@ -104,7 +101,7 @@ impl Misc for Client {
     /// Returns a vector of the languages that have gitignore templates on Github.
     fn get_gitignore_templates(&self) -> Result<Vec<String>> {
         let url = "https://api.github.com/gitignore/templates";
-        let data = get(url, self.headers.clone())?;
+        let data = get(url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&data))
     }
 
@@ -119,7 +116,7 @@ impl Misc for Client {
     fn get_gitignore_templates_lang(&self, lang: &str) -> Result<GitIgnore> {
         let mut url = String::from("https://api.github.com/gitignore/templates/");
         url.push_str(lang);
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&data))
     }
 
@@ -132,7 +129,7 @@ impl Misc for Client {
     fn post_markdown(&self, data: Markdown) -> Result<HTML> {
         let url = "https://api.github.com/markdown";
         let data = post(url,
-                        self.headers.clone(),
+                        self.get_headers().clone(),
                         serde_json::to_string(&data)?)?;
         try_serde!(serde_json::from_str(&data))
     }
@@ -149,14 +146,14 @@ impl Misc for Client {
     fn post_markdown_raw(&self, data: Markdown) -> Result<HTML> {
         let url = "https://api.github.com/markdown/raw";
         let data = post(url,
-                        self.headers.clone(),
+                        self.get_headers().clone(),
                         serde_json::to_string(&data)?)?;
         try_serde!(serde_json::from_str(&data))
     }
 
     // fn get_emojis(&self) -> String {
     //     let url = "https://api.github.com/emojis";
-    //     let data = get(url, self.headers.clone())
+    //     let data = get(url, self.get_headers().clone())
     // }
 
     // Experimental come back when stabilized

--- a/src/repositories.rs
+++ b/src/repositories.rs
@@ -1,5 +1,3 @@
-//! Trait definition related to Repositories on Github
-
 use requests::*;
 use github::Client;
 use error::*;
@@ -36,7 +34,7 @@ impl Repos for Client {
     fn post_org_repos(&self, organization: String, repo: RepoCreate) -> Result<Repo> {
         let url = format!("https://api.github.com/orgs/{}/repos", organization);
         let res = post(&url,
-                       self.headers.clone(),
+                       self.get_headers().clone(),
                        serde_json::to_string(&repo)?)?;
         try_serde!(serde_json::from_str(&res))
     }
@@ -50,7 +48,7 @@ impl Repos for Client {
     fn post_user_repos(&self, repo: RepoCreate) -> Result<Repo> {
         let url = "https://api.github.com/user/repos";
         let res = post(url,
-                       self.headers.clone(),
+                       self.get_headers().clone(),
                        serde_json::to_string(&repo)?)?;
         try_serde!(serde_json::from_str(&res))
     }

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -1,7 +1,6 @@
 //! Library calls to generate and manipulate requests to the
 //! Github API
 
-extern crate hyper;
 use hyper::header::{Accept, UserAgent, Authorization, Headers, qitem};
 use hyper::mime::Mime;
 use hyper::client::Client;
@@ -14,17 +13,63 @@ use std::io::Read;
 // Implement Conditional requests to reduce API calls w/ ETag headers
 // Add ability to allow CORS if requested.
 
+/// Various Media Types that can be used to access the Github API
+/// by default it just uses Json but various endpoints can return
+/// data differently based off the Media Type. Care should be used
+/// as some methods will fail given parsing to specific types.
+#[derive(Debug,Copy,Clone)]
+pub enum MediaType {
+    /// Get JSON back from the API
+    Json,
+    /// Get Raw JSON back from the API
+    RawJson,
+    /// Get Text in JSON form back from the API
+    TextJson,
+    /// Get HTML in JSON form back from the API
+    HtmlJson,
+    /// Get Full in JSON form back from the API
+    FullJson,
+    /// Get Diffs back from the API
+    Diff,
+    /// Get Patches back from the API
+    Patch,
+    /// Get Raw data back from the API
+    Raw,
+    /// Get SHA back from the API
+    Sha,
+    /// Get HTML back from the API
+    Html,
+    /// Get Base64 back from the API
+    Base64
+}
+
+/// Change a MediaType into it's coresponding Mime type for requests
+pub fn media_to_mime(media: MediaType) -> Result<Mime> {
+    match media {
+        // try_mime unwraps the value like try but converts to a github
+        // error otherwise however since it unwraps if it's okay we need to
+        // wrap it in an Ok if it is successful
+        MediaType::Json     => Ok(try_mime!("application/vnd.github.v3+json".parse())),
+        MediaType::RawJson  => Ok(try_mime!("application/vnd.github.v3.raw+json".parse())),
+        MediaType::TextJson => Ok(try_mime!("application/vnd.github.v3.text+json".parse())),
+        MediaType::HtmlJson => Ok(try_mime!("application/vnd.github.v3+html+json".parse())),
+        MediaType::FullJson => Ok(try_mime!("application/vnd.github.v3.full+json".parse())),
+        MediaType::Diff     => Ok(try_mime!("application/vnd.github.v3.diff".parse())),
+        MediaType::Patch    => Ok(try_mime!("application/vnd.github.v3.patch".parse())),
+        MediaType::Raw      => Ok(try_mime!("application/vnd.github.v3.raw".parse())),
+        MediaType::Sha      => Ok(try_mime!("application/vnd.github.v3.sha".parse())),
+        MediaType::Html     => Ok(try_mime!("application/vnd.github.v3.html".parse())),
+        MediaType::Base64   => Ok(try_mime!("application/vnd.github.v3.base64".parse())),
+    }
+}
+
 /// Default Headers returns a list with the user agent and `AccessToken`
 /// already in a list for use in a request to the API
 pub fn default_headers(auth_token: AccessToken) -> Result<Headers> {
     // Used to make sure we always request the v3 version of the API
     // so as to make these bindings stable
-    let mime: Mime = match "application/vnd.github.v3+json".parse() {
-        Ok(x) => x,
-        Err(_) => return Err(GithubError::LibError),
-    };
-    let mut token = String::from("token ");
-    token.push_str(&auth_token);
+    let mime: Mime = try_mime!("application/vnd.github.v3+json".parse());
+    let token = String::from("token ") + &auth_token;
 
     let mut headers = Headers::new();
     headers.set(UserAgent(String::from("github-rs")));

--- a/src/users.rs
+++ b/src/users.rs
@@ -1,13 +1,10 @@
 //! Trait defition related to the User on Github
-
-extern crate hyper;
-extern crate serde_json;
-
 use hyper::status::StatusCode;
 use json::{SSHKey, Email, User, PatchUser};
 use requests::*;
 use github::Client;
 use error::*;
+use serde_json;
 
 /// Trait used to define access to endpoints grouped under `Users` in the Github API
 /// specification
@@ -231,7 +228,7 @@ impl Users for Client {
     /// Returns a `User` Struct for the authenticated user.
     fn get_user(&self) -> Result<User> {
         let url = "https://api.github.com/user";
-        let data = get(url, self.headers.clone())?;
+        let data = get(url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&data))
 
     }
@@ -245,7 +242,7 @@ impl Users for Client {
     fn get_users_username(&self, username: &str) -> Result<User> {
         let mut url = String::from("https://api.github.com/users/");
         url.push_str(username);
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
 
         try_serde!(serde_json::from_str(&data))
     }
@@ -267,7 +264,7 @@ impl Users for Client {
             url.push_str(&num.to_string());
         }
 
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
 
         try_serde!(serde_json::from_str(&data))
     }
@@ -282,7 +279,7 @@ impl Users for Client {
     fn get_user_emails(&self, page_num: Option<u64>, per_page: Option<u64>) -> Result<Vec<Email>> {
         let mut url = String::from("https://api.github.com/user/emails");
         paginate!(url,page_num,per_page);
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&data))
     }
 
@@ -302,7 +299,7 @@ impl Users for Client {
         url.push_str(username);
         url.push_str("/followers");
         paginate!(url,page_num,per_page);
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&data))
     }
 
@@ -319,7 +316,7 @@ impl Users for Client {
                           -> Result<Vec<User>> {
         let mut url = String::from("https://api.github.com/user/followers");
         paginate!(url,page_num,per_page);
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&data))
 
     }
@@ -340,7 +337,7 @@ impl Users for Client {
         url.push_str(username);
         url.push_str("/following");
         paginate!(url,page_num,per_page);
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&data))
 
     }
@@ -358,7 +355,7 @@ impl Users for Client {
                           -> Result<Vec<User>> {
         let mut url = String::from("https://api.github.com/user/following");
         paginate!(url,page_num,per_page);
-        let data = get(&url, self.headers.clone())?;
+        let data = get(&url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&data))
 
     }
@@ -372,7 +369,7 @@ impl Users for Client {
     fn patch_user(&self, user: PatchUser) -> Result<User> {
         let url = "https://api.github.com/user";
         let res = patch(url,
-                        self.headers.clone(),
+                        self.get_headers().clone(),
                         serde_json::to_string(&user)?)?;
         try_serde!(serde_json::from_str(&res))
     }
@@ -386,7 +383,7 @@ impl Users for Client {
     fn post_user_emails(&self, emails: Vec<String>) -> Result<Vec<Email>> {
         let url = "https://api.github.com/user/emails";
         let res = post(url,
-                       self.headers.clone(),
+                       self.get_headers().clone(),
                        serde_json::to_string(&emails)?)?;
         try_serde!(serde_json::from_str(&res))
     }
@@ -400,7 +397,7 @@ impl Users for Client {
     fn put_user_following_username(&self, username: &str) -> Result<bool> {
         let mut url = String::from("https://api.github.com/user/following/");
         url.push_str(username);
-        let res = put(&url, self.headers.clone())?;
+        let res = put(&url, self.get_headers().clone())?;
         Ok(res == StatusCode::NoContent)
     }
 
@@ -414,7 +411,7 @@ impl Users for Client {
     fn delete_user_following_username(&self, username: &str) -> Result<bool> {
         let mut url = String::from("https://api.github.com/user/following/");
         url.push_str(username);
-        let res = delete(&url, self.headers.clone())?;
+        let res = delete(&url, self.get_headers().clone())?;
         Ok(res == StatusCode::NoContent)
     }
 
@@ -428,7 +425,7 @@ impl Users for Client {
     fn get_user_following_username(&self, username: &str) -> Result<bool> {
         let mut url = String::from("https://api.github.com/user/following/");
         url.push_str(username);
-        let res = get_status_code(&url, self.headers.clone())?;
+        let res = get_status_code(&url, self.get_headers().clone())?;
         Ok(res == StatusCode::NoContent)
     }
 
@@ -446,7 +443,7 @@ impl Users for Client {
         url.push_str(username);
         url.push_str("/following/");
         url.push_str(target_user);
-        let res = get_status_code(&url, self.headers.clone())?;
+        let res = get_status_code(&url, self.get_headers().clone())?;
         Ok(res == StatusCode::NoContent)
     }
 
@@ -460,7 +457,7 @@ impl Users for Client {
         let mut url = String::from("https://api.github.com/users/");
         url.push_str(username);
         url.push_str("/keys");
-        let res = get(&url, self.headers.clone())?;
+        let res = get(&url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&res))
     }
 
@@ -472,7 +469,7 @@ impl Users for Client {
     /// Returns a Vector of all `SSHKey`s that the authenticate user might have.
     fn get_user_keys(&self) -> Result<Vec<SSHKey>> {
         let url = "https://api.github.com/user/keys";
-        let res = get(url, self.headers.clone())?;
+        let res = get(url, self.get_headers().clone())?;
         try_serde!(serde_json::from_str(&res))
     }
 
@@ -486,7 +483,7 @@ impl Users for Client {
     fn get_user_keys_id(&self, id: u64) -> Result<Option<SSHKey>> {
         let mut url = String::from("https://api.github.com/user/keys/");
         url.push_str(&id.to_string());
-        let res = get(&url, self.headers.clone())?;
+        let res = get(&url, self.get_headers().clone())?;
 
         // Try and fix this
         if let Ok(serial) = serde_json::from_str(&res) {
@@ -505,7 +502,7 @@ impl Users for Client {
     fn post_user_keys(&self, new_key: SSHKey) -> Result<SSHKey> {
         let url = "https://api.github.com/user/keys";
         let res = post(url,
-                       self.headers.clone(),
+                       self.get_headers().clone(),
                        serde_json::to_string(&new_key)?)?;
         try_serde!(serde_json::from_str(&res))
 
@@ -521,7 +518,7 @@ impl Users for Client {
     fn delete_user_keys(&self, id: u64) -> Result<bool> {
         let mut url = String::from("https://api.github.com/user/keys");
         url.push_str(&id.to_string());
-        let res = delete(&url, self.headers.clone())?;
+        let res = delete(&url, self.get_headers().clone())?;
         Ok(res == StatusCode::NoContent)
     }
 
@@ -535,7 +532,7 @@ impl Users for Client {
     fn delete_user_emails(&self, emails: Vec<String>) -> Result<bool> {
         let url = "https://api.github.com/user/emails";
         let res = delete_with_data(url,
-                                   self.headers.clone(),
+                                   self.get_headers().clone(),
                                    serde_json::to_string(&emails)? )?;
         Ok(res == StatusCode::NoContent)
     }


### PR DESCRIPTION
As part of updating Client to accept media types I also implemented it so that you can set or get fields. This makes is that those modifying Client fields directly code will fail on the next release.