### PR TITLE
Add PUT, POST, PATCH, and DELETE

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ fn main() {
     match me {
         Ok((status, json)) => {
             println!("{}", status);
-            println!("{}", json);
+            if let Some(json) = json{
+                println!("{}", json);
+            }
         },
         Err(e) => println!("{}", e)
     }

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -207,7 +207,7 @@ GitHub V3 API
 - [ ] /repos/:owner/:repo/pulls/comments
 - [ ] /repos/:owner/:repo/releases
 - [ ] /repos/:owner/:repo/statuses/:sha
-- [ ] /user/emails
+- [X] /user/emails
 - [ ] /user/keys
 - [ ] /user/repos
 - [ ] https://<upload_url>/repos/:owner/:repo/releases/:id/assets?name=foo.zip
@@ -233,7 +233,7 @@ GitHub V3 API
 - [ ] /repos/:owner/:repo/pulls/:number/merge
 - [ ] /repos/:owner/:repo/subscription
 - [ ] /teams/:id/memberships/:username
-- [ ] /user/following/:username
+- [X] /user/following/:username
 - [ ] /user/starred/:owner/:repo
 
 ## DELETE
@@ -272,7 +272,7 @@ GitHub V3 API
 - [ ] /repos/:owner/:repo/subscription
 - [ ] /teams/:id
 - [ ] /teams/:id/memberships/:username
-- [ ] /user/emails
+- [X] /user/emails
 - [ ] /user/following/:username
 - [ ] /user/keys/:id
 - [ ] /user/starred/:owner/:repo
@@ -299,7 +299,7 @@ GitHub V3 API
 - [ ] /repos/:owner/:repo/releases/:id
 - [ ] /teams/:id
 - [ ] /user
-- [ ] /user/email/visibility
+- [X] /user/email/visibility
 
 GitHub V3 API Pre-release
 --------------------------------------------------------------------------------

--- a/examples/getting_started.rs
+++ b/examples/getting_started.rs
@@ -9,7 +9,9 @@ fn main() {
     match me {
         Ok((status, json)) => {
             println!("{}", status);
-            println!("{}", json);
+            if let Some(json) = json{
+                println!("{}", json);
+            }
         },
         Err(e) => println!("{}", e)
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -46,9 +46,6 @@ macro_rules! from {
             fn from(gh: &'a mut Github) -> Self {
                 use std::result;
                 use errors;
-                // I don't like using unwrap here but it's one of those things
-                // that never really fails at all because it's the creation of
-                // something.
                 let url = "https://api.github.com".parse::<Uri>()
                     .chain_err(||
                         "Url failed to parse"
@@ -126,7 +123,7 @@ macro_rules! exec {
         /// or the Status Code and Json after it has been deserialized.
         /// Please take a look at the GitHub documenation to see what value
         /// you should receive back for good or bad requests.
-        pub fn execute(self) -> Result<(StatusCode, Json)> {
+        pub fn execute(self) -> Result<(StatusCode, Option<Json>)> {
             let ex: Executor = self.into();
             ex.execute()
         }
@@ -138,7 +135,7 @@ macro_rules! exec {
             /// or the Status Code and Json after it has been deserialized.
             /// Please take a look at the GitHub documenation to see what value
             /// you should receive back for good or bad requests.
-            pub fn execute(self) -> Result<(StatusCode, Json)> {
+            pub fn execute(self) -> Result<(StatusCode, Option<Json>)> {
                 let ex: Executor = self.into();
                 ex.execute()
             }
@@ -176,6 +173,18 @@ macro_rules! func {
                     }
                 }
             }
+            self.into()
+        }
+    );
+}
+
+/// A variation of func for the client module that allows partitioning of types.
+/// Create a function with a given name and return type. Used for creating
+/// functions for simple conversions from one type to another, where the actual
+/// conversion code is in the From implementation.
+macro_rules! func_client{
+    ($i: ident, $t: ty) => (
+        pub fn $i(self) -> $t {
             self.into()
         }
     );

--- a/src/misc/get.rs
+++ b/src/misc/get.rs
@@ -4,9 +4,12 @@ use hyper::client::Request;
 use hyper::status::StatusCode;
 use hyper::Body;
 use errors::*;
-use client::Executor;
+use client::{GetQueryBuilder, Executor};
+use util::url_join;
 use Json;
 
+from!(GetQueryBuilder, Emojis, "emojis");
+from!(GetQueryBuilder, RateLimit, "rate_limit");
 new_type!(Emojis);
 new_type!(RateLimit);
 

--- a/src/users/delete.rs
+++ b/src/users/delete.rs
@@ -1,0 +1,22 @@
+//! Access the Users portion of the GitHub API
+use tokio_core::reactor::Core;
+use hyper::client::Request;
+use hyper::status::StatusCode;
+use hyper::Body;
+use errors::*;
+use util::url_join;
+use client::{ DeleteQueryBuilder, Executor };
+use Json;
+
+new_type!(User);
+new_type!(Emails);
+
+from!(DeleteQueryBuilder, User, "user");
+from!(User, Emails, "emails");
+from!(Emails, Executor);
+
+impl<'a> User<'a> {
+    func!(emails, Emails);
+}
+
+exec!(Emails);

--- a/src/users/get.rs
+++ b/src/users/get.rs
@@ -5,7 +5,7 @@ use hyper::status::StatusCode;
 use hyper::Body;
 use errors::*;
 use util::url_join;
-use client::Executor;
+use client::{GetQueryBuilder, Executor};
 use Json;
 
 // Declaration of types representing the various items under users
@@ -37,6 +37,8 @@ new_type!(StarredOwner);
 new_type!(Subscriptions);
 
 // From implementations for conversion
+from!(GetQueryBuilder, User, "user");
+from!(GetQueryBuilder, Users, "users");
 from!(Emails, Executor);
 from!(Events, Executor);
 from!(Events, EventsOrgs, "orgs");

--- a/src/users/patch.rs
+++ b/src/users/patch.rs
@@ -1,0 +1,28 @@
+//! Access the Users portion of the GitHub API
+use tokio_core::reactor::Core;
+use hyper::client::Request;
+use hyper::status::StatusCode;
+use hyper::Body;
+use errors::*;
+use util::url_join;
+use client::{ PatchQueryBuilder, Executor };
+use Json;
+
+new_type!(User);
+new_type!(Email);
+new_type!(Visibility);
+
+from!(PatchQueryBuilder, User, "user");
+from!(User, Email, "email");
+from!(Email, Visibility, "visibility");
+from!(Visibility, Executor);
+
+impl<'a> User<'a> {
+    func!(emails, Email);
+}
+
+impl<'a> Email<'a> {
+    func!(visibility, Visibility);
+}
+
+exec!(Visibility);

--- a/src/users/post.rs
+++ b/src/users/post.rs
@@ -1,0 +1,22 @@
+//! Access the Users portion of the GitHub API
+use tokio_core::reactor::Core;
+use hyper::client::Request;
+use hyper::status::StatusCode;
+use hyper::Body;
+use errors::*;
+use util::url_join;
+use client::{PostQueryBuilder, Executor};
+use Json;
+
+new_type!(User);
+new_type!(Emails);
+
+from!(PostQueryBuilder, User, "user");
+from!(User, Emails, "emails");
+from!(Emails, Executor);
+
+impl<'a> User<'a> {
+    func!(emails, Emails);
+}
+
+exec!(Emails);

--- a/src/users/put.rs
+++ b/src/users/put.rs
@@ -1,0 +1,28 @@
+//! Access the Users portion of the GitHub API
+use tokio_core::reactor::Core;
+use hyper::client::Request;
+use hyper::status::StatusCode;
+use hyper::Body;
+use errors::*;
+use util::url_join;
+use client::{ PutQueryBuilder, Executor };
+use Json;
+
+new_type!(User);
+new_type!(Following);
+new_type!(Username);
+
+from!(PutQueryBuilder, User, "user");
+from!(User, Following, "following");
+from!(Following, Username);
+from!(Username, Executor);
+
+impl<'a> User<'a> {
+    func!(following, Following);
+}
+
+impl<'a> Following<'a> {
+    func!(username, Username, username_str);
+}
+
+exec!(Username);


### PR DESCRIPTION
This commit adds the other request types that were needed for the library to
move forward. It shifts a few things around to get it to work but it works now.
It had to make the return type change to `(StatusCode, Option<Json>)` to work
as I found I was causing unwrapping on empty bodies to happen with things that
aren't returned. This also updates the accompanying docs/examples to work.

Either way maintainers now can implement any endtype without fear. It's now just
implementing all the endpoints!

Closes #24, #25, #26, and #27 