### PR TITLE
Add more endpoints including custom endpoints

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -43,7 +43,7 @@ GitHub V3 API
 - [ ] /repos/:owner/:repo/:archive_format/:ref
 - [X] /repos/:owner/:repo/assignees
 - [ ] /repos/:owner/:repo/assignees/:assignee
-- [ ] /repos/:owner/:repo/branches
+- [X] /repos/:owner/:repo/branches
 - [ ] /repos/:owner/:repo/branches/:branch
 - [ ] /repos/:owner/:repo/branches/:branch/protection
 - [ ] /repos/:owner/:repo/branches/:branch/protection/restrictions

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -52,7 +52,7 @@ GitHub V3 API
 - [ ] /repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews
 - [ ] /repos/:owner/:repo/branches/:branch/required_status_checks
 - [ ] /repos/:owner/:repo/branches/:branch/required_status_checks/contexts
-- [ ] /repos/:owner/:repo/collaborators
+- [X] /repos/:owner/:repo/collaborators
 - [ ] /repos/:owner/:repo/collaborators/:username
 - [ ] /repos/:owner/:repo/collaborators/:username/permission
 - [ ] /repos/:owner/:repo/comments

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -39,7 +39,7 @@ GitHub V3 API
 - [ ] /orgs/:org/repos
 - [ ] /orgs/:org/teams
 - [X] /rate_limit
-- [ ] /repos/:owner/:repo
+- [X] /repos/:owner/:repo
 - [ ] /repos/:owner/:repo/:archive_format/:ref
 - [ ] /repos/:owner/:repo/assignees
 - [ ] /repos/:owner/:repo/assignees/:assignee

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -41,7 +41,7 @@ GitHub V3 API
 - [X] /rate_limit
 - [X] /repos/:owner/:repo
 - [ ] /repos/:owner/:repo/:archive_format/:ref
-- [ ] /repos/:owner/:repo/assignees
+- [X] /repos/:owner/:repo/assignees
 - [ ] /repos/:owner/:repo/assignees/:assignee
 - [ ] /repos/:owner/:repo/branches
 - [ ] /repos/:owner/:repo/branches/:branch

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,6 +18,7 @@ use serde_json;
 // Internal Library Imports
 use users;
 use misc;
+use repos;
 use errors::*;
 use Json;
 
@@ -145,6 +146,7 @@ impl<'a> GetQueryBuilder<'a> {
     func_client!(rate_limit, misc::get::RateLimit<'a>);
     func_client!(user, users::get::User<'a>);
     func_client!(users, users::get::Users<'a>);
+    func_client!(repos, repos::get::Repos<'a>);
 }
 
 impl<'a> PutQueryBuilder<'a> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,6 +20,7 @@ use users;
 use misc;
 use repos;
 use errors::*;
+use util::url_join;
 use Json;
 
 /// Struct used to make calls to the Github API.
@@ -32,6 +33,7 @@ new_type!(PutQueryBuilder);
 new_type!(PostQueryBuilder);
 new_type!(DeleteQueryBuilder);
 new_type!(PatchQueryBuilder);
+new_type!(CustomQuery);
 new_type!(Executor);
 
 
@@ -142,6 +144,17 @@ impl Github {
 }
 
 impl<'a> GetQueryBuilder<'a> {
+    /// Pass in an endpoint not covered by the API in the form of the following:
+    ///
+    /// ```no_test
+    /// # Don't have the beginning / in it
+    /// repos/mgattozzi/github-rs
+    /// ```
+    ///
+    /// It can be whatever endpoint or url string that's needed. This will allow
+    /// you to get functionality out of the library as items are still added or
+    /// if you need access to a hidden endpoint.
+    func!(custom_endpoint, CustomQuery, endpoint_str);
     func_client!(emojis, misc::get::Emojis<'a>);
     func_client!(rate_limit, misc::get::RateLimit<'a>);
     func_client!(user, users::get::User<'a>);
@@ -150,20 +163,66 @@ impl<'a> GetQueryBuilder<'a> {
 }
 
 impl<'a> PutQueryBuilder<'a> {
+    /// Pass in an endpoint not covered by the API in the form of the following:
+    ///
+    /// ```no_test
+    /// # Don't have the beginning / in it
+    /// repos/mgattozzi/github-rs
+    /// ```
+    ///
+    /// It can be whatever endpoint or url string that's needed. This will allow
+    /// you to get functionality out of the library as items are still added or
+    /// if you need access to a hidden endpoint.
+    func!(custom_endpoint, CustomQuery, endpoint_str);
     func_client!(user, users::put::User<'a>);
 }
 
 impl<'a> DeleteQueryBuilder<'a> {
+    /// Pass in an endpoint not covered by the API in the form of the following:
+    ///
+    /// ```no_test
+    /// # Don't have the beginning / in it
+    /// repos/mgattozzi/github-rs
+    /// ```
+    ///
+    /// It can be whatever endpoint or url string that's needed. This will allow
+    /// you to get functionality out of the library as items are still added or
+    /// if you need access to a hidden endpoint.
+    func!(custom_endpoint, CustomQuery, endpoint_str);
     func_client!(user, users::delete::User<'a>);
 }
 
 impl<'a> PostQueryBuilder<'a> {
+    /// Pass in an endpoint not covered by the API in the form of the following:
+    ///
+    /// ```no_test
+    /// # Don't have the beginning / in it
+    /// repos/mgattozzi/github-rs
+    /// ```
+    ///
+    /// It can be whatever endpoint or url string that's needed. This will allow
+    /// you to get functionality out of the library as items are still added or
+    /// if you need access to a hidden endpoint.
+    func!(custom_endpoint, CustomQuery, endpoint_str);
     func_client!(user, users::post::User<'a>);
 }
 
 impl<'a> PatchQueryBuilder<'a> {
+    /// Pass in an endpoint not covered by the API in the form of the following:
+    ///
+    /// ```no_test
+    /// # Don't have the beginning / in it
+    /// repos/mgattozzi/github-rs
+    /// ```
+    ///
+    /// It can be whatever endpoint or url string that's needed. This will allow
+    /// you to get functionality out of the library as items are still added or
+    /// if you need access to a hidden endpoint.
+    func!(custom_endpoint, CustomQuery, endpoint_str);
     func_client!(user, users::patch::User<'a>);
 }
+
+exec!(CustomQuery);
 
 impl<'a> Executor<'a> {
 
@@ -201,3 +260,11 @@ from!(PutQueryBuilder, Method::Put);
 from!(PostQueryBuilder, Method::Post);
 from!(PatchQueryBuilder, Method::Patch);
 from!(DeleteQueryBuilder, Method::Delete);
+
+// Custom Url based from impls
+from!(GetQueryBuilder, CustomQuery);
+from!(PutQueryBuilder, CustomQuery);
+from!(PostQueryBuilder, CustomQuery);
+from!(PatchQueryBuilder, CustomQuery);
+from!(DeleteQueryBuilder, CustomQuery);
+from!(CustomQuery, Executor);

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -10,16 +10,19 @@ use Json;
 
 new_type!(Assignees);
 new_type!(Branches);
+new_type!(Collaborators);
 new_type!(Repo);
 new_type!(Repos);
 new_type!(Owner);
 
 from!(Assignees, Executor);
 from!(Branches, Executor);
+from!(Collaborators, Executor);
 from!(GetQueryBuilder, Repos, "repos");
 from!(Owner, Repo);
 from!(Repo, Assignees, "assignees");
 from!(Repo, Branches, "branches");
+from!(Repo, Collaborators, "collaborators");
 from!(Repo, Executor);
 from!(Repos, Owner);
 
@@ -32,6 +35,10 @@ impl<'a> Branches<'a> {
     exec!();
 }
 
+impl<'a> Collaborators<'a> {
+    exec!();
+}
+
 impl<'a> Owner<'a> {
     func!(repo, Repo, repo_str);
 }
@@ -39,6 +46,7 @@ impl<'a> Owner<'a> {
 impl<'a> Repo<'a> {
     func!(assignees, Assignees);
     func!(branches, Branches);
+    func!(collaborators, Collaborators);
     exec!();
 }
 

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -1,0 +1,30 @@
+//! Access the Repos portion of the GitHub API
+use tokio_core::reactor::Core;
+use hyper::client::Request;
+use hyper::status::StatusCode;
+use hyper::Body;
+use errors::*;
+use util::url_join;
+use client::{GetQueryBuilder, Executor};
+use Json;
+
+new_type!(Repos);
+new_type!(Owner);
+new_type!(Repo);
+
+from!(GetQueryBuilder, Repos, "repos");
+from!(Repos, Owner);
+from!(Owner, Repo);
+from!(Repo, Executor);
+
+impl<'a> Repos<'a> {
+    func!(owner, Owner, username_str);
+}
+
+impl<'a> Owner<'a> {
+    func!(repo, Repo, repo_str);
+}
+
+impl<'a> Repo<'a> {
+    exec!();
+}

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -9,19 +9,27 @@ use client::{GetQueryBuilder, Executor};
 use Json;
 
 new_type!(Assignees);
+new_type!(Branches);
 new_type!(Repo);
 new_type!(Repos);
 new_type!(Owner);
 
 from!(Assignees, Executor);
+from!(Branches, Executor);
 from!(GetQueryBuilder, Repos, "repos");
 from!(Owner, Repo);
 from!(Repo, Assignees, "assignees");
+from!(Repo, Branches, "branches");
 from!(Repo, Executor);
 from!(Repos, Owner);
 
-impl<'a> Repos<'a> {
-    func!(owner, Owner, username_str);
+
+impl<'a> Assignees<'a> {
+    exec!();
+}
+
+impl<'a> Branches<'a> {
+    exec!();
 }
 
 impl<'a> Owner<'a> {
@@ -30,9 +38,10 @@ impl<'a> Owner<'a> {
 
 impl<'a> Repo<'a> {
     func!(assignees, Assignees);
+    func!(branches, Branches);
     exec!();
 }
 
-impl<'a> Assignees<'a> {
-    exec!();
+impl<'a> Repos<'a> {
+    func!(owner, Owner, username_str);
 }

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -8,14 +8,17 @@ use util::url_join;
 use client::{GetQueryBuilder, Executor};
 use Json;
 
+new_type!(Assignees);
+new_type!(Repo);
 new_type!(Repos);
 new_type!(Owner);
-new_type!(Repo);
 
+from!(Assignees, Executor);
 from!(GetQueryBuilder, Repos, "repos");
-from!(Repos, Owner);
 from!(Owner, Repo);
+from!(Repo, Assignees, "assignees");
 from!(Repo, Executor);
+from!(Repos, Owner);
 
 impl<'a> Repos<'a> {
     func!(owner, Owner, username_str);
@@ -26,5 +29,10 @@ impl<'a> Owner<'a> {
 }
 
 impl<'a> Repo<'a> {
+    func!(assignees, Assignees);
+    exec!();
+}
+
+impl<'a> Assignees<'a> {
     exec!();
 }

--- a/src/users/get.rs
+++ b/src/users/get.rs
@@ -156,13 +156,11 @@ impl<'a> EventsOrgs<'a> {
 }
 
 impl<'a> Keys<'a> {
-    // This is a status based call, will need to figure out
     func!(id, KeysId, id_str);
     exec!();
 }
 
 impl<'a> Following<'a> {
-    // This is a status based call, will need to figure out
     func!(username, Following, username_str);
     exec!();
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,8 +2,8 @@ use hyper::Uri;
 use hyper::error::UriError;
 use std::str::FromStr;
 
-/// Work around function for Url.join() until it gets fixed upstream.
-/// Adds the value passed in to the Url path
+/// Add an extra subdirectory to the end of the url. This utilizes
+/// Hyper's more generic Uri type. We've set it up to act as a Url.
 pub fn url_join(url: &Uri, path: &str) -> Result<Uri, UriError> {
     // Absolutely hackish but don't know anything better
     match (url.scheme(), url.authority(), url.path()) {
@@ -18,7 +18,8 @@ pub fn url_join(url: &Uri, path: &str) -> Result<Uri, UriError> {
             curr_path.push_str(path);
             curr_path.parse::<Uri>()
         },
-        // I think this will do it
-        _ => Uri::from_str("fail"),
+        // This should cause the request to fail if something goes
+        // wrong.
+        _ => Uri::from_str("Failed to make a valid Url"),
     }
 }

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -17,10 +17,13 @@ fn get_user_repos() {
     // We want it to fail
     let mut g = Github::new(&auth_token().unwrap());
     let (status, json) = g.get()
-                          .user()
                           .repos()
+                          .owner("mgattozzi")
+                          .repo("github-rs")
                           .execute()
                           .unwrap();
     println!("{}", status);
-    println!("{}", json);
+    if let Some(json) = json {
+        println!("{}", json);
+    }
 }


### PR DESCRIPTION
Adds a few more endpoints, beginning the monstrosity that is the /repos/:owner/:repo set of endpoints for get requests. This also cleans up a few stray or outdated comments but the main thing is that custom endpoints were added. Context from the commit itself:

> It might be a while to get the library to a completely usable state. In the
> meantime we should still allow users to be able to use endpoints not covered in
> the code base. On top of that some users might need access to hidden endpoints
> and those are not publically available. This is the solution for these problems.
> While not foolproof since users might mistype the string being used as input it
> still allows flexibility.
>
> The main draw is that users can still use this API as is and as patches come out
> adding new endpoints they can move the code over to that.