### PR TITLE
Switch Core to Rc<RefCell<Core>> in Github Struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ documentation = "https://mgattozzi.github.io/github-rs"
 [dependencies]
 hyper = { git = "https://github.com/hyperium/hyper" }
 hyper-tls = { git = "https://github.com/hyperium/hyper-tls" }
-error-chain = "*"
+error-chain = "0.10"
 tokio-core = "0.1"
-futures = "*"
+futures = "0.1"
 serde = "0.9"
 serde_json = "0.9"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ extern crate github_rs;
 use github_rs::client::Github;
 
 fn main() {
-    let mut client = Github::new("API TOKEN");
+    let client = Github::new("API TOKEN");
     let me = client.get()
                    .user()
                    .execute();

--- a/examples/getting_started.rs
+++ b/examples/getting_started.rs
@@ -2,7 +2,7 @@ extern crate github_rs;
 use github_rs::client::Github;
 
 fn main() {
-    let mut client = Github::new("API TOKEN");
+    let client = Github::new("API TOKEN");
     let me = client.get()
                    .user()
                    .execute();

--- a/src/misc/get.rs
+++ b/src/misc/get.rs
@@ -1,12 +1,6 @@
 //! Access the Misc portion of the GitHub API
-use tokio_core::reactor::Core;
-use hyper::client::Request;
-use hyper::status::StatusCode;
-use hyper::Body;
-use errors::*;
+imports!();
 use client::{GetQueryBuilder, Executor};
-use util::url_join;
-use Json;
 
 from!(GetQueryBuilder, Emojis, "emojis");
 from!(GetQueryBuilder, RateLimit, "rate_limit");

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -1,12 +1,6 @@
 //! Access the Repos portion of the GitHub API
-use tokio_core::reactor::Core;
-use hyper::client::Request;
-use hyper::status::StatusCode;
-use hyper::Body;
-use errors::*;
-use util::url_join;
+imports!();
 use client::{GetQueryBuilder, Executor};
-use Json;
 
 new_type!(Assignees);
 new_type!(Branches);
@@ -27,29 +21,29 @@ from!(Repo, Executor);
 from!(Repos, Owner);
 
 
-impl<'a> Assignees<'a> {
+impl Assignees {
     exec!();
 }
 
-impl<'a> Branches<'a> {
+impl Branches {
     exec!();
 }
 
-impl<'a> Collaborators<'a> {
+impl Collaborators {
     exec!();
 }
 
-impl<'a> Owner<'a> {
+impl Owner {
     func!(repo, Repo, repo_str);
 }
 
-impl<'a> Repo<'a> {
+impl Repo {
     func!(assignees, Assignees);
     func!(branches, Branches);
     func!(collaborators, Collaborators);
     exec!();
 }
 
-impl<'a> Repos<'a> {
+impl Repos {
     func!(owner, Owner, username_str);
 }

--- a/src/users/delete.rs
+++ b/src/users/delete.rs
@@ -1,12 +1,6 @@
 //! Access the Users portion of the GitHub API
-use tokio_core::reactor::Core;
-use hyper::client::Request;
-use hyper::status::StatusCode;
-use hyper::Body;
-use errors::*;
-use util::url_join;
+imports!();
 use client::{ DeleteQueryBuilder, Executor };
-use Json;
 
 new_type!(User);
 new_type!(Emails);
@@ -15,7 +9,7 @@ from!(DeleteQueryBuilder, User, "user");
 from!(User, Emails, "emails");
 from!(Emails, Executor);
 
-impl<'a> User<'a> {
+impl User {
     func!(emails, Emails);
 }
 

--- a/src/users/get.rs
+++ b/src/users/get.rs
@@ -1,12 +1,6 @@
 //! Access the Users portion of the GitHub API
-use tokio_core::reactor::Core;
-use hyper::client::Request;
-use hyper::status::StatusCode;
-use hyper::Body;
-use errors::*;
-use util::url_join;
+imports!();
 use client::{GetQueryBuilder, Executor};
-use Json;
 
 // Declaration of types representing the various items under users
 new_type!(Emails);
@@ -96,16 +90,16 @@ from!(User, Repos, "repos");
 from!(Repos, Executor);
 
 // impls of each type
-impl<'a> Starred<'a> {
+impl Starred {
     func!(owner, StarredOwner, owner_str);
     exec!();
 }
 
-impl<'a> StarredOwner<'a> {
+impl StarredOwner {
     func!(repo, StarredRepo, repo_str);
 }
 
-impl<'a> User<'a> {
+impl User {
     func!(emails, Emails);
     func!(followers, Followers);
     func!(following, Following);
@@ -118,12 +112,12 @@ impl<'a> User<'a> {
     exec!();
 }
 
-impl<'a> Users<'a> {
+impl Users {
     func!(username, UsersUsername, username_str);
     exec!();
 }
 
-impl<'a> UserUsername<'a> {
+impl UserUsername {
     func!(followers, Followers);
     func!(following, Following);
     func!(keys, UsersKeys);
@@ -131,7 +125,7 @@ impl<'a> UserUsername<'a> {
     exec!();
 }
 
-impl<'a> UsersUsername<'a> {
+impl UsersUsername {
     func!(events, Events);
     func!(followers, Followers);
     func!(following, Following);
@@ -145,27 +139,27 @@ impl<'a> UsersUsername<'a> {
     exec!();
 }
 
-impl<'a> Events<'a> {
+impl Events {
     func!(orgs, EventsOrgs);
     func!(public, Public);
     exec!();
 }
 
-impl<'a> EventsOrgs<'a> {
+impl EventsOrgs {
     func!(org, EventsOrgsName, org_name_str);
 }
 
-impl<'a> Keys<'a> {
+impl Keys {
     func!(id, KeysId, id_str);
     exec!();
 }
 
-impl<'a> Following<'a> {
+impl Following {
     func!(username, Following, username_str);
     exec!();
 }
 
-impl<'a> ReceivedEvents<'a> {
+impl ReceivedEvents {
     exec!();
 }
 

--- a/src/users/patch.rs
+++ b/src/users/patch.rs
@@ -1,12 +1,6 @@
 //! Access the Users portion of the GitHub API
-use tokio_core::reactor::Core;
-use hyper::client::Request;
-use hyper::status::StatusCode;
-use hyper::Body;
-use errors::*;
-use util::url_join;
+imports!();
 use client::{ PatchQueryBuilder, Executor };
-use Json;
 
 new_type!(User);
 new_type!(Email);
@@ -17,11 +11,11 @@ from!(User, Email, "email");
 from!(Email, Visibility, "visibility");
 from!(Visibility, Executor);
 
-impl<'a> User<'a> {
+impl User {
     func!(emails, Email);
 }
 
-impl<'a> Email<'a> {
+impl Email {
     func!(visibility, Visibility);
 }
 

--- a/src/users/post.rs
+++ b/src/users/post.rs
@@ -1,12 +1,6 @@
 //! Access the Users portion of the GitHub API
-use tokio_core::reactor::Core;
-use hyper::client::Request;
-use hyper::status::StatusCode;
-use hyper::Body;
-use errors::*;
-use util::url_join;
+imports!();
 use client::{PostQueryBuilder, Executor};
-use Json;
 
 new_type!(User);
 new_type!(Emails);
@@ -15,7 +9,7 @@ from!(PostQueryBuilder, User, "user");
 from!(User, Emails, "emails");
 from!(Emails, Executor);
 
-impl<'a> User<'a> {
+impl User {
     func!(emails, Emails);
 }
 

--- a/src/users/put.rs
+++ b/src/users/put.rs
@@ -1,12 +1,6 @@
 //! Access the Users portion of the GitHub API
-use tokio_core::reactor::Core;
-use hyper::client::Request;
-use hyper::status::StatusCode;
-use hyper::Body;
-use errors::*;
-use util::url_join;
+imports!();
 use client::{ PutQueryBuilder, Executor };
-use Json;
 
 new_type!(User);
 new_type!(Following);
@@ -17,11 +11,11 @@ from!(User, Following, "following");
 from!(Following, Username);
 from!(Username, Executor);
 
-impl<'a> User<'a> {
+impl User {
     func!(following, Following);
 }
 
-impl<'a> Following<'a> {
+impl Following {
     func!(username, Username, username_str);
 }
 

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -15,7 +15,7 @@ fn auth_token() -> Result<String, std::io::Error> {
 #[test]
 fn get_user_repos() {
     // We want it to fail
-    let mut g = Github::new(&auth_token().unwrap());
+    let g = Github::new(&auth_token().unwrap());
     let (status, json) = g.get()
                           .repos()
                           .owner("mgattozzi")


### PR DESCRIPTION
Before we had no good way to expose the event loop to users if they needed it
because doing so would violate the ownership rules. On top of that the lifetime
annotations and problems with the old implementation were a hastle to deal with.
If we limit the need for mutability with a user they have more flexibility due
to the imutability, especially with this API. Functionality will later expose the event loop to users if they want to have access to it.