### PR TITLE
Headers and ETags

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ fn main() {
                    .user()
                    .execute();
     match me {
-        Ok((status, json)) => {
+        Ok((headers, status, json)) => {
+            println!("{}", headers);
             println!("{}", status);
             if let Some(json) = json{
                 println!("{}", json);

--- a/examples/cached_responses.rs
+++ b/examples/cached_responses.rs
@@ -1,0 +1,29 @@
+extern crate github_rs;
+use github_rs::client::Github;
+use github_rs::headers::{ etag, rate_limit_remaining };
+
+fn main() {
+    let client = Github::new("Your Auth Token Here");
+    let me = client.get()
+                   .user()
+                   .execute();
+    match me {
+        Ok((headers, _, _)) => {
+
+            if let Some(etag) = etag(&headers) {
+                let limit = rate_limit_remaining(&headers);
+                let (headers, _, _) = client.get()
+                                            .set_etag(etag)
+                                            .user()
+                                            .execute()
+                                            .expect("Well I existed before");
+                if let Some(limit) = limit {
+                    println!("Asserting they are equal!");
+                    assert_eq!(limit, rate_limit_remaining(&headers).unwrap());
+                    println!("They are!");
+                }
+            }
+        },
+        Err(e) => println!("{}", e)
+    }
+}

--- a/examples/getting_started.rs
+++ b/examples/getting_started.rs
@@ -7,7 +7,8 @@ fn main() {
                    .user()
                    .execute();
     match me {
-        Ok((status, json)) => {
+        Ok((headers, status, json)) => {
+            println!("{}", headers);
             println!("{}", status);
             if let Some(json) = json{
                 println!("{}", json);

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use tokio_core::reactor::Core;
 use hyper::{ Body, Headers, Uri, Method, Error };
 use hyper::client::{ Client, Request };
 use hyper::header::{ Authorization, Accept, ContentType,
-                     ETag, UserAgent, qitem };
+                     ETag, IfNoneMatch, UserAgent, qitem };
 use hyper::mime::Mime;
 use hyper::status::StatusCode;
 use hyper_tls::HttpsConnector;
@@ -221,7 +221,8 @@ impl <'g> GetQueryBuilder<'g> {
     pub fn set_etag(self, tag: ETag) -> Self {
         match self.request {
             Ok(mut req) => {
-                req.get_mut().headers_mut().set(tag);
+                let ETag(tag) = tag;
+                req.get_mut().headers_mut().set(IfNoneMatch::Items(vec![tag]));
                 Self {
                     request: Ok(req),
                     core: self.core,
@@ -250,7 +251,8 @@ impl <'g> PutQueryBuilder<'g> {
     pub fn set_etag(mut self, tag: ETag) -> Self {
         match self.request {
             Ok(mut req) => {
-                req.get_mut().headers_mut().set(tag);
+                let ETag(tag) = tag;
+                req.get_mut().headers_mut().set(IfNoneMatch::Items(vec![tag]));
                 self.request = Ok(req);
                 self
             }
@@ -277,7 +279,8 @@ impl <'g> DeleteQueryBuilder<'g> {
     pub fn set_etag(mut self, tag: ETag) -> Self {
         match self.request {
             Ok(mut req) => {
-                req.get_mut().headers_mut().set(tag);
+                let ETag(tag) = tag;
+                req.get_mut().headers_mut().set(IfNoneMatch::Items(vec![tag]));
                 self.request = Ok(req);
                 self
             }
@@ -304,7 +307,8 @@ impl <'g> PostQueryBuilder<'g> {
     pub fn set_etag(mut self, tag: ETag) -> Self {
         match self.request {
             Ok(mut req) => {
-                req.get_mut().headers_mut().set(tag);
+                let ETag(tag) = tag;
+                req.get_mut().headers_mut().set(IfNoneMatch::Items(vec![tag]));
                 self.request = Ok(req);
                 self
             },
@@ -331,7 +335,8 @@ impl <'g> PatchQueryBuilder<'g> {
     pub fn set_etag(mut self, tag: ETag) -> Self {
         match self.request {
             Ok(mut req) => {
-                req.get_mut().headers_mut().set(tag);
+                let ETag(tag) = tag;
+                req.get_mut().headers_mut().set(IfNoneMatch::Items(vec![tag]));
                 self.request = Ok(req);
                 self
             }

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,0 +1,70 @@
+//! Helper functions for end users for GitHub response Headers
+use std::str;
+use std::str::FromStr;
+use hyper::header::{ ETag, Headers, LastModified, UserAgent };
+
+/// Checks to see if a received payload from GitHub contains
+/// the GitHub-Hookshot header in the `UserAgent`.
+pub fn has_github_hookshot(head: &Headers) -> bool {
+    head.get::<UserAgent>()
+        .map_or(false, |user_agent| {
+            match user_agent {
+                &UserAgent(ref raw) => raw.starts_with("GitHub-Hookshot"),
+            }
+        })
+}
+
+/// Extract an ETag from the Headers if it exists
+pub fn etag(head: &Headers) -> Option<ETag> {
+    head.get::<ETag>()
+        .map(|tag| tag.to_owned())
+}
+
+/// Extract the Last-Modified from the Headers if it exists
+pub fn last_modified(head: &Headers) -> Option<LastModified> {
+    head.get::<LastModified>()
+        .map(|modified| modified.to_owned())
+}
+
+
+/// Extract however many requests the authenticated user can
+/// do from the Headers
+pub fn rate_limit_remaining(head: &Headers) -> Option<u32> {
+    head.get_raw("X-RateLimit-Remaining")
+        .map(|limit| {
+            u32::from_str(
+                str::from_utf8(limit.one()
+                                    .unwrap_or(&[]))
+                .unwrap_or("")
+            ).ok()
+        })
+        .unwrap_or(None)
+}
+
+/// Extract however many requests the authenticated user can
+/// make from the Headers
+pub fn rate_limit(head: &Headers) -> Option<u32> {
+    head.get_raw("X-RateLimit-Limit")
+        .map(|limit| {
+            u32::from_str(
+                str::from_utf8(limit.one()
+                                    .unwrap_or(&[]))
+                .unwrap_or("")
+            ).ok()
+        })
+        .unwrap_or(None)
+}
+
+/// Extract when the requests limit for the authenticated user
+/// is reset from the Headers
+pub fn rate_limit_reset(head: &Headers) -> Option<u32> {
+    head.get_raw("X-RateLimit-Reset")
+        .map(|limit| {
+            u32::from_str(
+                str::from_utf8(limit.one()
+                                    .unwrap_or(&[]))
+                .unwrap_or("")
+            ).ok()
+        })
+        .unwrap_or(None)
+}

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -8,9 +8,7 @@ use hyper::header::{ ETag, Headers, LastModified, UserAgent };
 pub fn has_github_hookshot(head: &Headers) -> bool {
     head.get::<UserAgent>()
         .map_or(false, |user_agent| {
-            match user_agent {
-                &UserAgent(ref raw) => raw.starts_with("GitHub-Hookshot"),
-            }
+            user_agent.starts_with("GitHub-Hookshot")
         })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,13 @@ extern crate serde_json;
 
 #[macro_use] mod macros;
 mod util;
+
 pub mod errors {
     error_chain!{}
 }
 pub mod client;
 pub mod gists;
+pub mod headers;
 pub mod issues;
 pub mod misc;
 pub mod notifications;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -67,7 +67,7 @@ macro_rules! from {
                         {
                             let mut headers = req.headers_mut();
                             headers.set(ContentType::json());
-                            headers.set(UserAgent(String::from("github-rs")));
+                            headers.set(UserAgent::new(String::from("github-rs")));
                             headers.set(Accept(vec![qitem(m)]));
                             headers.set(Authorization(token));
                         }

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -21,29 +21,29 @@ from!(Repo, Executor);
 from!(Repos, Owner);
 
 
-impl Assignees {
+impl <'g> Assignees<'g> {
     exec!();
 }
 
-impl Branches {
+impl <'g> Branches<'g> {
     exec!();
 }
 
-impl Collaborators {
+impl <'g> Collaborators<'g> {
     exec!();
 }
 
-impl Owner {
+impl <'g> Owner<'g> {
     func!(repo, Repo, repo_str);
 }
 
-impl Repo {
+impl <'g> Repo<'g> {
     func!(assignees, Assignees);
     func!(branches, Branches);
     func!(collaborators, Collaborators);
     exec!();
 }
 
-impl Repos {
+impl <'g> Repos<'g> {
     func!(owner, Owner, username_str);
 }

--- a/src/users/delete.rs
+++ b/src/users/delete.rs
@@ -9,7 +9,7 @@ from!(DeleteQueryBuilder, User, "user");
 from!(User, Emails, "emails");
 from!(Emails, Executor);
 
-impl User {
+impl <'g> User<'g> {
     func!(emails, Emails);
 }
 

--- a/src/users/get.rs
+++ b/src/users/get.rs
@@ -90,16 +90,16 @@ from!(User, Repos, "repos");
 from!(Repos, Executor);
 
 // impls of each type
-impl Starred {
+impl <'g> Starred<'g> {
     func!(owner, StarredOwner, owner_str);
     exec!();
 }
 
-impl StarredOwner {
+impl <'g> StarredOwner<'g> {
     func!(repo, StarredRepo, repo_str);
 }
 
-impl User {
+impl <'g> User<'g> {
     func!(emails, Emails);
     func!(followers, Followers);
     func!(following, Following);
@@ -112,12 +112,12 @@ impl User {
     exec!();
 }
 
-impl Users {
+impl <'g> Users<'g> {
     func!(username, UsersUsername, username_str);
     exec!();
 }
 
-impl UserUsername {
+impl <'g> UserUsername<'g> {
     func!(followers, Followers);
     func!(following, Following);
     func!(keys, UsersKeys);
@@ -125,7 +125,7 @@ impl UserUsername {
     exec!();
 }
 
-impl UsersUsername {
+impl <'g> UsersUsername<'g> {
     func!(events, Events);
     func!(followers, Followers);
     func!(following, Following);
@@ -139,27 +139,27 @@ impl UsersUsername {
     exec!();
 }
 
-impl Events {
+impl <'g> Events<'g> {
     func!(orgs, EventsOrgs);
     func!(public, Public);
     exec!();
 }
 
-impl EventsOrgs {
+impl <'g> EventsOrgs<'g> {
     func!(org, EventsOrgsName, org_name_str);
 }
 
-impl Keys {
+impl <'g> Keys<'g> {
     func!(id, KeysId, id_str);
     exec!();
 }
 
-impl Following {
+impl <'g> Following<'g> {
     func!(username, Following, username_str);
     exec!();
 }
 
-impl ReceivedEvents {
+impl <'g> ReceivedEvents<'g> {
     exec!();
 }
 

--- a/src/users/patch.rs
+++ b/src/users/patch.rs
@@ -11,11 +11,11 @@ from!(User, Email, "email");
 from!(Email, Visibility, "visibility");
 from!(Visibility, Executor);
 
-impl User {
+impl <'g> User<'g> {
     func!(emails, Email);
 }
 
-impl Email {
+impl <'g> Email<'g> {
     func!(visibility, Visibility);
 }
 

--- a/src/users/post.rs
+++ b/src/users/post.rs
@@ -9,7 +9,7 @@ from!(PostQueryBuilder, User, "user");
 from!(User, Emails, "emails");
 from!(Emails, Executor);
 
-impl User {
+impl <'g> User<'g> {
     func!(emails, Emails);
 }
 

--- a/src/users/put.rs
+++ b/src/users/put.rs
@@ -11,11 +11,11 @@ from!(User, Following, "following");
 from!(Following, Username);
 from!(Username, Executor);
 
-impl User {
+impl <'g> User<'g> {
     func!(following, Following);
 }
 
-impl Following {
+impl <'g> Following<'g> {
     func!(username, Username, username_str);
 }
 

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -16,12 +16,13 @@ fn auth_token() -> Result<String, std::io::Error> {
 fn get_user_repos() {
     // We want it to fail
     let g = Github::new(&auth_token().unwrap());
-    let (status, json) = g.get()
-                          .repos()
-                          .owner("mgattozzi")
-                          .repo("github-rs")
-                          .execute()
-                          .unwrap();
+    let (headers, status, json) = g.get()
+                                   .repos()
+                                   .owner("mgattozzi")
+                                   .repo("github-rs")
+                                   .execute()
+                                   .unwrap();
+    println!("{}", headers);
     println!("{}", status);
     if let Some(json) = json {
         println!("{}", json);


### PR DESCRIPTION
This PR adds Headers to the value returned and helper functions to extract certain GitHub specific Header items from it. On top of that it add support for ETags to use cached values if possible. This doesn't go against your GitHub rate limit and is a desirable feature if you're querying a specific bit of data often. Also include a breakage fix from Hyper today. Also fixes an issue where the GitHub struct was moved if called more than once which was undesirable behavior.

Closes #20 