### PR TITLE
Expose the Github Core with a method

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -83,6 +83,27 @@ impl Github {
         self.token = token.to_owned();
     }
 
+    /// Exposes the inner event loop for those who need
+    /// access to it. The reccomended way to safely access
+    /// the core would be
+    ///
+    /// ```rust,no_test
+    /// let g = Github::new("API KEY");
+    /// let core = g.get_core();
+    /// // Handle the error here.
+    /// let ref mut core_mut = *core.try_borrow_mut()?;
+    /// // Do stuff with the core here. This prevents a runtime failure by
+    /// // having two mutable borrows to the core at the same time.
+    /// ```
+    ///
+    /// This is how other parts of the API are implemented to avoid causing your
+    /// program to crash unexpectedly. While you could borrow without the
+    /// `Result` being handled it's highly reccomended you don't unless you know
+    /// there is no other mutable reference to it.
+    pub fn get_core(&self) -> &Rc<RefCell<Core>> {
+        &self.core
+    }
+
     /// Begin building up a GET request to GitHub
     pub fn get(&self) -> GetQueryBuilder {
         self.into()

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -23,7 +23,6 @@ fn get_user_repos() {
                                    .repo("github-rs")
                                    .execute()
                                    .unwrap();
-    let etag = etag(&headers);
     println!("{}", headers);
     println!("{}", status);
     if let Some(json) = json {
@@ -42,7 +41,8 @@ fn cached_response() {
                            .execute()
                            .unwrap();
     let etag = etag(&headers);
-    let limit = rate_limit_remaining(&headers).unwrap();
+    //let limit = rate_limit_remaining(&headers).unwrap();
+    let _ = rate_limit_remaining(&headers).unwrap();
     let (headers, _, _) = g.get()
                            .set_etag(etag.unwrap())
                            .repos()
@@ -50,7 +50,17 @@ fn cached_response() {
                            .repo("github-rs")
                            .execute()
                            .unwrap();
-    let limit2 = rate_limit_remaining(&headers).unwrap();
+    //let limit2 = rate_limit_remaining(&headers).unwrap();
+    let _ = rate_limit_remaining(&headers).unwrap();
     // Spurious test case
     //assert_eq!(limit, limit2);
+}
+
+#[test]
+fn core_exposure() {
+    let g = Github::new(&auth_token().unwrap());
+    // Can we get the core for users to have?
+    let core = g.get_core();
+    let ref mut core_mut = *core.try_borrow_mut().unwrap();
+    let _ = core_mut.handle();
 }


### PR DESCRIPTION
People oftentimes don't want to keep constructing the Event loop just to use it. For users with more advanced needs it has been exposed via a function for them to use.