### PR TITLE
tls: use rustls as tls backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://mgattozzi.github.io/github-rs"
 
 [dependencies]
 hyper = "0.11"
-hyper-tls = "0.1"
+hyper-rustls = "0.8"
 error-chain = "0.10"
 tokio-core = "0.1"
 futures = "0.1"

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,12 +5,12 @@ use tokio_core::reactor::Core;
 
 // Hyper Imports
 use hyper::{ Body, Headers, Uri, Method, Error };
-use hyper::client::{ Client, HttpConnector, Request };
+use hyper::client::{ Client, Request };
 use hyper::header::{ Authorization, Accept, ContentType,
                      ETag, IfNoneMatch, UserAgent, qitem };
 use hyper::mime::Mime;
 use hyper::StatusCode;
-use hyper_tls::HttpsConnector;
+use hyper_rustls::HttpsConnector;
 
 // Serde Imports
 use serde::Serialize;
@@ -31,7 +31,7 @@ use std::cell::RefCell;
 pub struct Github {
     token: String,
     core: Rc<RefCell<Core>>,
-    client: Rc<Client<HttpsConnector<HttpConnector>>>,
+    client: Rc<Client<HttpsConnector>>,
 }
 
 impl Clone for Github {
@@ -75,8 +75,7 @@ impl Github {
         let core = Core::new().chain_err(|| "Unable to build a new Core")?;
         let handle = core.handle();
         let client = Client::configure()
-            .connector(HttpsConnector::new(4,&handle)
-                       .chain_err(|| "Unable to build HttpsConnector")?)
+            .connector(HttpsConnector::new(4,&handle))
             .build(&handle);
         Ok(Self {
             token: token.as_ref().into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 #[macro_use]
 extern crate error_chain;
 extern crate hyper;
-extern crate hyper_tls;
+extern crate hyper_rustls;
 extern crate futures;
 extern crate tokio_core;
 extern crate serde;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -128,7 +128,7 @@ macro_rules! new_type {
         pub struct $i<'g> {
             pub(crate) request: Result<RefCell<Request<Body>>>,
             pub(crate) core: &'g Rc<RefCell<Core>>,
-            pub(crate) client: &'g Rc<Client<HttpsConnector<HttpConnector>>>,
+            pub(crate) client: &'g Rc<Client<HttpsConnector>>,
         }
         )*
     );
@@ -260,9 +260,8 @@ macro_rules! func_client{
 macro_rules! imports{
     () => (
         use tokio_core::reactor::Core;
-        use hyper_tls::HttpsConnector;
+        use hyper_rustls::HttpsConnector;
         use hyper::client::Client;
-        use hyper::client::HttpConnector;
         use hyper::client::Request;
         use hyper::StatusCode;
         use hyper::{ Body, Headers };


### PR DESCRIPTION
This commit changes the TLS backend from hyper-tls to hyper-rustls,
allowing this package to run on systems without the openssl library
installed (and thus allowing it to run on all systems that Rust can
compile to).