### PR TITLE
repos: add new get and post endpoints

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -57,12 +57,15 @@ GitHub V3 API
 - [ ] /repos/:owner/:repo/collaborators/:username/permission
 - [ ] /repos/:owner/:repo/comments
 - [ ] /repos/:owner/:repo/comments/:id
-- [ ] /repos/:owner/:repo/commits
+- [X] /repos/:owner/:repo/commits
 - [ ] /repos/:owner/:repo/commits/:ref
 - [ ] /repos/:owner/:repo/commits/:ref/comments
 - [ ] /repos/:owner/:repo/commits/:ref/status
 - [ ] /repos/:owner/:repo/commits/:ref/statuses
-- [ ] /repos/:owner/:repo/commits/:sha
+- [X] /repos/:owner/:repo/commits/:sha
+- [X] /repos/:owner/:repo/commits/:sha/comments
+- [X] /repos/:owner/:repo/commits/:sha/status
+- [X] /repos/:owner/:repo/commits/:sha/statuses
 - [ ] /repos/:owner/:repo/compare/:base...:head
 - [ ] /repos/:owner/:repo/contents/:path
 - [ ] /repos/:owner/:repo/contributors
@@ -100,15 +103,15 @@ GitHub V3 API
 - [ ] /repos/:owner/:repo/pages/builds
 - [ ] /repos/:owner/:repo/pages/builds/:id
 - [ ] /repos/:owner/:repo/pages/builds/latest
-- [ ] /repos/:owner/:repo/pulls
-- [ ] /repos/:owner/:repo/pulls/comments
-- [ ] /repos/:owner/:repo/pulls/comments/:id
-- [ ] /repos/:owner/:repo/pulls/:number
-- [ ] /repos/:owner/:repo/pulls/:number/comments
-- [ ] /repos/:owner/:repo/pulls/:number/commits
-- [ ] /repos/:owner/:repo/pulls/:number/files
-- [ ] /repos/:owner/:repo/pulls/:number/requested_reviewers
-- [ ] /repos/:owner/:repo/pulls/:number/merge
+- [X] /repos/:owner/:repo/pulls
+- [X] /repos/:owner/:repo/pulls/comments
+- [X] /repos/:owner/:repo/pulls/comments/:id
+- [X] /repos/:owner/:repo/pulls/:number
+- [X] /repos/:owner/:repo/pulls/:number/comments
+- [X] /repos/:owner/:repo/pulls/:number/commits
+- [X] /repos/:owner/:repo/pulls/:number/files
+- [X] /repos/:owner/:repo/pulls/:number/requested_reviewers
+- [X] /repos/:owner/:repo/pulls/:number/merge
 - [ ] /repos/:owner/:repo/readme
 - [ ] /repos/:owner/:repo/releases
 - [ ] /repos/:owner/:repo/releases/assets/:id
@@ -206,7 +209,7 @@ GitHub V3 API
 - [ ] /repos/:owner/:repo/pulls
 - [ ] /repos/:owner/:repo/pulls/comments
 - [ ] /repos/:owner/:repo/releases
-- [ ] /repos/:owner/:repo/statuses/:sha
+- [X] /repos/:owner/:repo/statuses/:sha
 - [X] /user/emails
 - [ ] /user/keys
 - [ ] /user/repos

--- a/src/client.rs
+++ b/src/client.rs
@@ -333,6 +333,7 @@ impl <'g> PostQueryBuilder<'g> {
     /// if you need access to a hidden endpoint.
     func_client!(custom_endpoint, CustomQuery, endpoint_str);
     func_client!(user, users::post::User<'g>);
+    func_client!(repos, repos::post::Repos<'g>);
 
     /// Add an etag to the headers of the request
     pub fn set_etag(mut self, tag: ETag) -> Self {

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -6,9 +6,23 @@ new_type!(
     Assignees
     Branches
     Collaborators
+    CommitsSha
+    CommitsComments
+    CommitsStatus
+    CommitsStatuses
+    Commits
     Repo
     Repos
     Owner
+    Pulls
+    PullsComments
+    PullsCommentsId
+    PullsNumber
+    PullsNumberComments
+    PullsNumberCommits
+    PullsNumberFiles
+    PullsNumberRequestedReviewers
+    PullsNumberMerge
 );
 
 from!(
@@ -17,6 +31,24 @@ from!(
     @Branches
        => Executor
     @Collaborators
+       => Executor
+    @CommitsSha
+       -> CommitsComments = "comments"
+    @CommitsSha
+       -> CommitsStatus = "status"
+    @CommitsSha
+       -> CommitsStatuses = "statuses"
+    @CommitsSha
+       => Executor
+    @CommitsComments
+       => Executor
+    @CommitsStatus
+       => Executor
+    @CommitsStatuses
+       => Executor
+    @Commits
+       => CommitsSha
+    @Commits
        => Executor
     @GetQueryBuilder
        -> Repos = "repos"
@@ -29,9 +61,49 @@ from!(
     @Repo
        -> Collaborators = "collaborators"
     @Repo
+       -> Commits = "commits"
+    @Repo
+       -> Pulls = "pulls"
+    @Repo
        => Executor
     @Repos
        => Owner
+
+    @Pulls
+       => Executor
+    @Pulls
+       -> PullsComments = "comments"
+    @PullsComments
+       => Executor
+    @PullsComments
+       => PullsCommentsId
+    @PullsCommentsId
+       => Executor
+    @Pulls
+       => PullsNumber
+    @PullsNumber
+       => Executor
+    @PullsNumber
+       -> PullsNumberComments = "comments"
+    @PullsNumberComments
+       => Executor
+    @PullsNumber
+       -> PullsNumberCommits = "commits"
+    @PullsNumberCommits
+       => Executor
+    @PullsNumber
+       -> PullsNumberFiles = "files"
+    @PullsNumberFiles
+       => Executor
+    @PullsNumber
+       -> PullsNumberRequestedReviewers = "requested_reviewers"
+    @PullsNumberRequestedReviewers
+       => Executor
+    @PullsNumber
+       -> PullsNumberMerge = "merge"
+    @PullsNumberMerge
+       => Executor
+
 );
 
 impl_macro!(
@@ -44,6 +116,28 @@ impl_macro!(
     @Collaborators
         |
         |-> execute
+    @CommitsSha
+        |=> comments -> CommitsComments
+        |=> status -> CommitsStatus
+        |=> statuses -> CommitsStatuses
+        |
+        |-> execute
+    @CommitsComments
+        |
+        |-> execute
+    @CommitsStatus
+        |
+        |-> execute
+    @CommitsStatuses
+        |
+        |-> execute
+
+    @Commits
+        |
+        |=> sha -> CommitsSha = sha_str
+    @Commits
+        |
+        |->execute
 
     @Owner
         |
@@ -52,10 +146,53 @@ impl_macro!(
         |=> assignees ->  Assignees
         |=> branches ->  Branches
         |=> collaborators ->  Collaborators
+        |=> commits -> Commits
+        |=> pulls -> Pulls
         |
         |-> execute
 
     @Repos
         |
         |=> owner ->  Owner = username_str
+
+    @Pulls
+        |=> comments -> PullsComments
+        |
+        |-> execute
+    @Pulls
+        |
+        |=> number -> PullsNumber = number_str
+
+    @PullsComments
+        |
+        |=> id -> PullsCommentsId = id_str
+    @PullsComments
+        |
+        |-> execute
+    @PullsCommentsId
+        |
+        |-> execute
+    @PullsNumber
+        |=> comments -> PullsNumberComments
+        |=> commits -> PullsNumberCommits
+        |=> files -> PullsNumberFiles
+        |=> requested_reviewers -> PullsNumberRequestedReviewers
+        |=> merge -> PullsNumberMerge
+        |
+        |-> execute
+    @PullsNumberComments
+        |
+        |-> execute
+    @PullsNumberCommits
+        |
+        |-> execute
+    @PullsNumberFiles
+        |
+        |-> execute
+    @PullsNumberRequestedReviewers
+        |
+        |-> execute
+    @PullsNumberMerge
+        |
+        |-> execute
 );

--- a/src/repos/post.rs
+++ b/src/repos/post.rs
@@ -1,0 +1,44 @@
+//! Access the Repos portion of the GitHub API
+imports!();
+use client::{PostQueryBuilder, Executor};
+
+new_type!(
+    Sha
+    Statuses
+    Repo
+    Repos
+    Owner
+);
+
+from!(
+    @Sha
+        => Executor
+    @PostQueryBuilder
+        -> Repos = "repos"
+    @Repos
+        => Owner
+    @Owner
+        => Repo
+    @Repo
+        -> Statuses = "statuses"
+    @Statuses
+        => Sha
+);
+
+impl_macro!(
+    @Sha
+        |
+        |-> execute
+    @Repos
+        |
+        |=> owner ->  Owner = username_str
+    @Owner
+        |
+        |=> repo -> Repo = repo_str
+    @Repo
+        |=> statuses -> Statuses
+        |
+    @Statuses
+        |
+        |=> sha -> Sha = sha_str
+);


### PR DESCRIPTION
This adds a bunch of endpoints that are being used in a project I am
working on. You can see what endpoints were added in the
docs/endpoints.md file.

I did not add any endpoints with "ref" as that is a reserved keyword in 
rust and cannot be used directly as a function (that may have to be
worked around eventually).