### PR TITLE
update the link to the documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.5.0"
 license = "MIT"
 repository = "https://github.com/mgattozzi/github-rs.git"
 homepage = "https://github.com/mgattozzi/github-rs"
-documentation = "https://mgattozzi.github.io/github-rs"
+documentation = "https://docs.rs/github-rs/0.5.0/github_rs/"
 
 [dependencies]
 hyper = "0.11"


### PR DESCRIPTION
Old document is pointed at [crates.io](https://crates.io/crates/github-rs)