### PR TITLE
repos: add remaining endpoints for collaborators

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -53,8 +53,8 @@ GitHub V3 API
 - [ ] /repos/:owner/:repo/branches/:branch/required_status_checks
 - [ ] /repos/:owner/:repo/branches/:branch/required_status_checks/contexts
 - [X] /repos/:owner/:repo/collaborators
-- [ ] /repos/:owner/:repo/collaborators/:username
-- [ ] /repos/:owner/:repo/collaborators/:username/permission
+- [X] /repos/:owner/:repo/collaborators/:username
+- [X] /repos/:owner/:repo/collaborators/:username/permission
 - [ ] /repos/:owner/:repo/comments
 - [ ] /repos/:owner/:repo/comments/:id
 - [X] /repos/:owner/:repo/commits

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -6,6 +6,8 @@ new_type!(
     Assignees
     Branches
     Collaborators
+    CollaboratorsUsername
+    CollaboratorsUsernamePermission
     CommitsSha
     CommitsComments
     CommitsStatus
@@ -31,6 +33,12 @@ from!(
     @Branches
        => Executor
     @Collaborators
+       => CollaboratorsUsername
+       => Executor
+    @CollaboratorsUsername
+       => Executor
+       -> CollaboratorsUsernamePermission = "permission"
+    @CollaboratorsUsernamePermission
        => Executor
     @CommitsSha
        -> CommitsComments = "comments"
@@ -114,6 +122,14 @@ impl_macro!(
         |
         |-> execute
     @Collaborators
+        |
+        |=> username -> CollaboratorsUsername = username
+        |-> execute
+    @CollaboratorsUsername
+        |=> permission -> CollaboratorsUsernamePermission
+        |
+        |-> execute
+    @CollaboratorsUsernamePermission
         |
         |-> execute
     @CommitsSha


### PR DESCRIPTION
This adds the :username and :username/permission endpoint for
repos/:owner/:repo/collaborators.