### PR TITLE
client: allow deserializing into any deserializable type

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -13,6 +13,7 @@ use hyper::StatusCode;
 use hyper_rustls::HttpsConnector;
 
 // Serde Imports
+use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json;
 
@@ -380,7 +381,8 @@ exec!(CustomQuery);
 
 impl <'g> Executor<'g> {
 
-    pub fn execute(self) -> Result<(Headers, StatusCode, Option<Json>)> {
+    pub fn execute<T>(self) -> Result<(Headers, StatusCode, Option<T>)>
+        where T: DeserializeOwned {
         let mut core_ref = self.core
                             .try_borrow_mut()
                             .chain_err(|| "Unable to get mutable borrow \


### PR DESCRIPTION
This allows clients to skip another deserialize step.

---
There is the issue here that non-success results will give an error JSON result rather than `T`. Maybe there should be a `Github` error variant which grabs the message out of these results? See [this code](https://gitlab.kitware.com/utils/rust-gitlab/blob/master/src/error.rs#L40) for Gitlab.