### PR TITLE
Small corrections to README code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ github-rs = "0.5"
 Then in your `lib.rs` or `main.rs` file add:
 
 ```rust
-extern crate github_rs
+extern crate github_rs;
 use github_rs::client::Github;
 ```
 
@@ -64,7 +64,7 @@ extern crate github_rs;
 use github_rs::client::Github;
 
 fn main() {
-    let client = Github::new("API TOKEN");
+    let client = Github::new("API TOKEN").unwrap();
     let me = client.get()
                    .user()
                    .execute();


### PR DESCRIPTION
Thanks for your hard work and open source contributions.

Adds a missing final semicolon for an `extern` statement and adds a
call to `.unwrap()` when creating the initial github-rs client, since
that returns a `Result`.