### PR TITLE
client, macro: deserialize into any deserializable

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -23,7 +23,6 @@ use misc;
 use repos;
 use errors::*;
 use util::url_join;
-use Json;
 
 use std::rc::Rc;
 use std::cell::RefCell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,5 +32,3 @@ pub mod repos;
 pub mod search;
 pub mod teams;
 pub mod users;
-
-pub type Json = serde_json::Value;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -145,7 +145,8 @@ macro_rules! exec {
         /// or the Status Code and Json after it has been deserialized.
         /// Please take a look at the GitHub documenation to see what value
         /// you should receive back for good or bad requests.
-        pub fn execute(self) -> Result<(Headers, StatusCode, Option<Json>)> {
+        pub fn execute<T>(self) -> Result<(Headers, StatusCode, Option<T>)>
+        where T: DeserializeOwned {
             let ex: Executor = self.into();
             ex.execute()
         }
@@ -157,8 +158,9 @@ macro_rules! exec {
             /// or the Status Code and Json after it has been deserialized.
             /// Please take a look at the GitHub documenation to see what value
             /// you should receive back for good or bad requests.
-            pub fn execute(self) ->
-                Result<(Headers, StatusCode, Option<Json>)> {
+            pub fn execute<T>(self) ->
+                Result<(Headers, StatusCode, Option<T>)>
+            where T: DeserializeOwned {
 
                 let ex: Executor = self.into();
                 ex.execute()
@@ -209,8 +211,8 @@ macro_rules! impl_macro {
                 /// Json after it has been deserialized. Please take a look at
                 /// the GitHub documenation to see what value you should receive
                 /// back for good or bad requests.
-                pub fn $id3(self) -> Result<(Headers, StatusCode, Option<Json>)>
-                {
+                pub fn $id3<T>(self) -> Result<(Headers, StatusCode, Option<T>)>
+                where T: DeserializeOwned {
                     let ex: Executor = self.into();
                     ex.execute()
                 }
@@ -267,7 +269,7 @@ macro_rules! imports{
         use hyper::{ Body, Headers };
         use errors::*;
         use util::url_join;
-        use Json;
+        use serde::de::DeserializeOwned;
         use std::rc::Rc;
         use std::cell::RefCell;
     );


### PR DESCRIPTION
This is a follow up on 6d33e8a which will allow results to be
automatically deserialize into any deserializable type. It will allow
code like the following:

```rust
struct PullRequest {
    title: String,
    body: String,
}

let pr: (_, _, PullRequest) = client
    .get()
    .repos()
    .owner(&repo.owner)
    .repo(&repo.repo)
    .pulls()
    .number(&number.to_string())
    .execute()
    .unwrap();
```