### PR TITLE
lib: expose hyper headers and statuscode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,3 +32,5 @@ pub mod repos;
 pub mod search;
 pub mod teams;
 pub mod users;
+
+pub use hyper::{Headers, StatusCode};


### PR DESCRIPTION
This is necessary in order to do comparison against the results of
execute().