### PR TITLE
macros: introduce executor trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ tokio-core = "0.1"
 futures = "0.1"
 serde = "1.0"
 serde_json = "1.0"
+
+[dev-dependencies]
+serde_derive = "1.0"

--- a/docs/design.md
+++ b/docs/design.md
@@ -142,25 +142,15 @@ macros you need to understand, how to use them, and what they do:
       @TypeA                       //    called, returns a B with a GET/POST
         |?> func -> TypeB = param  //    parameter. 'param' is the name of the
   );                               //    variable and is for documentation
-  impl_macro!(                     //<-- Create a function 'func' which executes
-      @TypeA                       //    the request. 'func' is always named
-        |-> func                   //    named "execute" for clarity
-  );
   ```
 
-- `exec!`
-  It can be used in two ways:
+- `exec!` is used to terminate the request chain. The result is an
+  implementation of the Executor trait on the type. This allows the execute
+  method to be called in order to actually perform the request.
 
   ```rust
-  exec!(TypeA);            //<-- Creates an impl for TypeA with only the exec
-                           //    function. Use if there is nothing else the
-                           //    type needs. If it has all the information
-                           //    it needs then it's ready to execute the
-                           //    request.
-  impl<'a> TypeA<'a> {
-    func!(TypeA, TypeB, parameter),
-    exec!(),               //<-- Creates the exec function in this impl since
-                           //    it can transform to another type or it has
-                           //    a valid url/values to execute a request
+  exec!(TypeA);            //<-- Creates an impl of Executor for Type A. This
+                           //    is neccessary for every type which needs an
+                           //    execute method.
   }
   ```

--- a/examples/cached_responses.rs
+++ b/examples/cached_responses.rs
@@ -1,6 +1,6 @@
 extern crate github_rs;
 extern crate serde_json;
-use github_rs::client::Github;
+use github_rs::client::{ Executor, Github };
 use github_rs::headers::{ etag, rate_limit_remaining };
 use serde_json::Value;
 

--- a/examples/getting_started.rs
+++ b/examples/getting_started.rs
@@ -1,6 +1,6 @@
 extern crate github_rs;
 extern crate serde_json;
-use github_rs::client::Github;
+use github_rs::client::{ Executor, Github };
 use serde_json::Value;
 
 fn main() {

--- a/examples/wrapping_responses.rs
+++ b/examples/wrapping_responses.rs
@@ -1,0 +1,44 @@
+extern crate github_rs;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+
+use github_rs::StatusCode;
+use github_rs::client::{ Executor, Github };
+use serde_json::Value;
+
+trait TryExecute: Executor {
+    fn try_execute(self) -> Result<Value, String>
+    where
+        Self: Sized,
+    {
+        #[derive(Deserialize)]
+        struct GithubError {
+            message: String,
+        }
+
+        match self.execute::<Value>() {
+            Ok((_, StatusCode::Ok, Some(response))) => Ok(response),
+            Ok((_, _, Some(response))) => {
+                serde_json::from_value::<GithubError>(response)
+                    .map_err(|err| format!("Failed to parse error response: {}", err))
+                    .and_then(|error| Err(error.message.into()))
+            }
+            Ok((_, _, None)) => Err("Received error response from github with no message".into()),
+            Err(err) => Err(format!("Failed to execute request: {}", err)),
+        }
+    }
+}
+
+impl<'a> TryExecute for ::github_rs::users::get::User<'a> {}
+
+fn main() {
+    let client = Github::new("API TOKEN").unwrap();
+    let result = client.get()
+                   .user()
+                   .try_execute();
+    match result {
+        Ok(me) => println!("{}", me),
+        Err(err) => println!("{}", err),
+    }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -204,37 +204,47 @@ macro_rules! new_type {
 
 /// Used to generate an execute function for a terminal type in a query
 /// pipeline. If passed a type it creates the impl as well as it needs
-/// no extra functions. If blank it just creates the function and should be
-/// used this way only inside an impl
+/// no extra functions.
 macro_rules! exec {
-    () => (
-        /// Execute the query by sending the built up request
-        /// to GitHub. The value returned is either an error
-        /// or the Status Code and Json after it has been deserialized.
-        /// Please take a look at the GitHub documenation to see what value
-        /// you should receive back for good or bad requests.
-        pub fn execute<T>(self) -> Result<(Headers, StatusCode, Option<T>)>
-        where T: DeserializeOwned {
-            let ex: Executor = self.into();
-            ex.execute()
-        }
-    );
     ($t: ident) => (
-        impl<'g> $t<'g> {
-            /// Execute the query by sending the built up request
-            /// to GitHub. The value returned is either an error
-            /// or the Status Code and Json after it has been deserialized.
-            /// Please take a look at the GitHub documenation to see what value
-            /// you should receive back for good or bad requests.
-            pub fn execute<T>(self) ->
-                Result<(Headers, StatusCode, Option<T>)>
-            where T: DeserializeOwned {
-
-                let ex: Executor = self.into();
-                ex.execute()
-
+        impl<'a> Executor for $t<'a> {
+            /// Execute the query by sending the built up request to GitHub.
+            /// The value returned is either an error or the Status Code and
+            /// Json after it has been deserialized. Please take a look at
+            /// the GitHub documenation to see what value you should receive
+            /// back for good or bad requests.
+            fn execute<T>(self) -> Result<(Headers, StatusCode, Option<T>)>
+            where T: DeserializeOwned
+            {
+                let mut core_ref = self.core
+                    .try_borrow_mut()
+                    .chain_err(|| "Unable to get mutable borrow \
+                                          to the event loop")?;
+                let client = self.client;
+                let work = client
+                    .request(self.request?.into_inner())
+                    .and_then(|res| {
+                        let header = res.headers().clone();
+                        let status = res.status();
+                        res.body().fold(Vec::new(), |mut v, chunk| {
+                            v.extend(&chunk[..]);
+                            ok::<_, hyper::Error>(v)
+                        }).map(move |chunks| {
+                            if chunks.is_empty() {
+                                Ok((header, status, None))
+                            } else {
+                                Ok((
+                                        header,
+                                        status,
+                                        Some(serde_json::from_slice(&chunks)
+                                             .chain_err(|| "Failed to parse response body")?)
+                                   ))
+                            }
+                        })
+                    });
+                core_ref.run(work).chain_err(|| "Failed to execute request")?
             }
-        }
+         }
     );
 }
 
@@ -243,8 +253,8 @@ macro_rules! exec {
 macro_rules! impl_macro {
     ($(@$i: ident $(|=> $id1: ident -> $t1: ident)*|
      $(|=> $id2: ident -> $t2: ident = $e2: ident)*
-     $(|?> $id3: ident -> $t3: ident = $e3: ident)*
-     $(|-> $id4: ident )*)+)=> (
+     $(|?> $id3: ident -> $t3: ident = $e3: ident)*)+
+    )=> (
         $(
             impl<'g> $i <'g>{
             $(
@@ -278,17 +288,6 @@ macro_rules! impl_macro {
                 pub fn $id3(mut self, $e3: &str) -> $t3<'g> {
                     self.parameter = Some($e3.to_string());
                     self.into()
-                }
-            )*$(
-                /// Execute the query by sending the built up request to GitHub.
-                /// The value returned is either an error or the Status Code and
-                /// Json after it has been deserialized. Please take a look at
-                /// the GitHub documenation to see what value you should receive
-                /// back for good or bad requests.
-                pub fn $id4<T>(self) -> Result<(Headers, StatusCode, Option<T>)>
-                where T: DeserializeOwned {
-                    let ex: Executor = self.into();
-                    ex.execute()
                 }
             )*
             }
@@ -340,12 +339,17 @@ macro_rules! imports{
         use hyper::client::Client;
         use hyper::client::Request;
         use hyper::StatusCode;
-        use hyper::{ Body, Headers, Uri };
+        use hyper::{ self, Body, Headers, Uri };
         use errors::*;
+        use futures::{ Future, Stream };
+        use futures::future::ok;
         use util::url_join;
         use serde::de::DeserializeOwned;
+        use serde_json;
         use std::rc::Rc;
         use std::cell::RefCell;
         use std::str::FromStr;
+
+        use $crate::client::Executor;
     );
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -19,6 +19,8 @@ macro_rules! from {
         )*$(
         impl <'g> From<$f<'g>> for $i1<'g> {
             fn from(mut f: $f<'g>) -> Self {
+                use std::str::FromStr;
+
                 // This is borrow checking abuse and about the only
                 // time I'd do is_ok(). Essentially this allows us
                 // to either pass the error message along or update
@@ -35,7 +37,7 @@ macro_rules! from {
                                     .uri()
                                     .query()
                                     .is_some() { "&" } else { "?" };
-                            Uri::from_str(
+                            hyper::Uri::from_str(
                                 &format!("{}{}{}={}",
                                     req.get_mut().uri(),
                                     sep,
@@ -134,7 +136,7 @@ macro_rules! from {
                         let mut req = Request::new($p, u);
                         let token = String::from("token ") + &gh.token;
                         {
-                            let mut headers = req.headers_mut();
+                            let headers = req.headers_mut();
                             headers.set(ContentType::json());
                             headers.set(UserAgent::new(String::from("github-rs")));
                             headers.set(Accept(vec![qitem(m)]));
@@ -339,7 +341,7 @@ macro_rules! imports{
         use hyper::client::Client;
         use hyper::client::Request;
         use hyper::StatusCode;
-        use hyper::{ self, Body, Headers, Uri };
+        use hyper::{ self, Body, Headers };
         use errors::*;
         use futures::{ Future, Stream };
         use futures::future::ok;
@@ -348,7 +350,6 @@ macro_rules! imports{
         use serde_json;
         use std::rc::Rc;
         use std::cell::RefCell;
-        use std::str::FromStr;
 
         use $crate::client::Executor;
     );

--- a/src/misc/get.rs
+++ b/src/misc/get.rs
@@ -1,6 +1,6 @@
 //! Access the Misc portion of the GitHub API
 imports!();
-use client::{GetQueryBuilder, Executor};
+use client::GetQueryBuilder;
 
 new_type!(
     Emojis
@@ -17,32 +17,10 @@ from!(
        -> Feeds = "feeds"
        -> Meta = "meta"
        -> RateLimit = "rate_limit"
-    @Emojis
-       => Executor
-    @Events
-       => Executor
-    @Feeds
-       => Executor
-    @Meta
-       => Executor
-    @RateLimit
-       => Executor
 );
 
-impl_macro!(
-    @Emojis
-        |
-        |-> execute
-    @Events
-        |
-        |-> execute
-    @Feeds
-        |
-        |-> execute
-    @Meta
-        |
-        |-> execute
-    @RateLimit
-        |
-        |-> execute
-);
+exec!(Emojis);
+exec!(Events);
+exec!(Feeds);
+exec!(Meta);
+exec!(RateLimit);

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -1,6 +1,6 @@
 //! Access the Repos portion of the GitHub API
 imports!();
-use client::{GetQueryBuilder, Executor};
+use client::GetQueryBuilder;
 
 new_type!(
     Assignees
@@ -36,61 +36,32 @@ new_type!(
 );
 
 from!(
-    @Assignees
-       => Executor
-    @Branches
-       => Executor
     @Collaborators
        => CollaboratorsUsername
-       => Executor
     @CollaboratorsUsername
-       => Executor
        -> CollaboratorsUsernamePermission = "permission"
-    @CollaboratorsUsernamePermission
-       => Executor
     @CommitsSha
        -> CommitsComments = "comments"
     @CommitsSha
        -> CommitsStatus = "status"
     @CommitsSha
        -> CommitsStatuses = "statuses"
-    @CommitsSha
-       => Executor
-    @CommitsComments
-       => Executor
-    @CommitsStatus
-       => Executor
-    @CommitsStatuses
-       => Executor
     @Commits
        => CommitsSha
-    @Commits
-       => Executor
 
     @Contents
        => ContentsPath
     @ContentsPath
        ?> ContentsReference = "ref"
-       => Executor
-    @ContentsReference
-       => Executor
 
     @Issues
        -> IssuesComments = "comments"
     @Issues
        => IssuesNumber
-       => Executor
     @IssuesComments
        => IssuesCommentsId
-       => Executor
-    @IssuesCommentsId
-       => Executor
     @IssuesNumber
        -> IssuesNumberComments = "comments"
-    @IssuesNumber
-       => Executor
-    @IssuesNumberComments
-       => Executor
     @GetQueryBuilder
        -> Repos = "repos"
     @Owner
@@ -108,120 +79,58 @@ from!(
     @Repo
        -> Pulls = "pulls"
        -> Issues = "issues"
-    @Repo
-       => Executor
     @Repos
        => Owner
 
     @Pulls
-       => Executor
-    @Pulls
        -> PullsComments = "comments"
     @PullsComments
-       => Executor
-    @PullsComments
        => PullsCommentsId
-    @PullsCommentsId
-       => Executor
     @Pulls
        => PullsNumber
     @PullsNumber
-       => Executor
-    @PullsNumber
        -> PullsNumberComments = "comments"
-    @PullsNumberComments
-       => Executor
     @PullsNumber
        -> PullsNumberCommits = "commits"
-    @PullsNumberCommits
-       => Executor
     @PullsNumber
        -> PullsNumberFiles = "files"
-    @PullsNumberFiles
-       => Executor
     @PullsNumber
        -> PullsNumberRequestedReviewers = "requested_reviewers"
-    @PullsNumberRequestedReviewers
-       => Executor
     @PullsNumber
        -> PullsNumberMerge = "merge"
-    @PullsNumberMerge
-       => Executor
-
 );
 
 impl_macro!(
-    @Assignees
-        |
-        |-> execute
-    @Branches
-        |
-        |-> execute
     @Collaborators
         |
         |=> username -> CollaboratorsUsername = username
-        |-> execute
     @CollaboratorsUsername
         |=> permission -> CollaboratorsUsernamePermission
         |
-        |-> execute
-    @CollaboratorsUsernamePermission
-        |
-        |-> execute
     @CommitsSha
         |=> comments -> CommitsComments
         |=> status -> CommitsStatus
         |=> statuses -> CommitsStatuses
         |
-        |-> execute
-    @CommitsComments
-        |
-        |-> execute
-    @CommitsStatus
-        |
-        |-> execute
-    @CommitsStatuses
-        |
-        |-> execute
-
     @Commits
         |
         |=> sha -> CommitsSha = sha_str
-    @Commits
-        |
-        |-> execute
-
     @Contents
         |
         |=> path -> ContentsPath = path_str
     @ContentsPath
         |
         |?> reference -> ContentsReference = ref_str
-        |-> execute
-    @ContentsReference
-        |
-        |-> execute
-
     @Issues
         |=> comments -> IssuesComments
         |
         |=> number -> IssuesNumber = issue_number
-        |-> execute
     @IssuesComments
         |
         |=> id -> IssuesCommentsId = comment_id
-        |-> execute
-    @IssuesCommentsId
-        |
-        |-> execute
     @IssuesNumber
         |=> comments -> IssuesNumberComments
         |
-        |-> execute
-    @IssuesNumberComments
-        |
-        |-> execute
-
     @Owner
         |
         |=> repo -> Repo = repo_str
@@ -234,29 +143,18 @@ impl_macro!(
         |=> pulls -> Pulls
         |=> issues -> Issues
         |
-        |-> execute
-
     @Repos
         |
         |=> owner ->  Owner = username_str
-
     @Pulls
         |=> comments -> PullsComments
         |
-        |-> execute
     @Pulls
         |
         |=> number -> PullsNumber = number_str
-
     @PullsComments
         |
         |=> id -> PullsCommentsId = id_str
-    @PullsComments
-        |
-        |-> execute
-    @PullsCommentsId
-        |
-        |-> execute
     @PullsNumber
         |=> comments -> PullsNumberComments
         |=> commits -> PullsNumberCommits
@@ -264,20 +162,32 @@ impl_macro!(
         |=> requested_reviewers -> PullsNumberRequestedReviewers
         |=> merge -> PullsNumberMerge
         |
-        |-> execute
-    @PullsNumberComments
-        |
-        |-> execute
-    @PullsNumberCommits
-        |
-        |-> execute
-    @PullsNumberFiles
-        |
-        |-> execute
-    @PullsNumberRequestedReviewers
-        |
-        |-> execute
-    @PullsNumberMerge
-        |
-        |-> execute
 );
+
+exec!(Assignees);
+exec!(Branches);
+exec!(Collaborators);
+exec!(CollaboratorsUsername);
+exec!(CollaboratorsUsernamePermission);
+exec!(Commits);
+exec!(CommitsSha);
+exec!(CommitsComments);
+exec!(CommitsStatus);
+exec!(CommitsStatuses);
+exec!(ContentsPath);
+exec!(ContentsReference);
+exec!(Issues);
+exec!(IssuesComments);
+exec!(IssuesCommentsId);
+exec!(IssuesNumber);
+exec!(IssuesNumberComments);
+exec!(Repo);
+exec!(Pulls);
+exec!(PullsComments);
+exec!(PullsCommentsId);
+exec!(PullsNumber);
+exec!(PullsNumberComments);
+exec!(PullsNumberCommits);
+exec!(PullsNumberFiles);
+exec!(PullsNumberRequestedReviewers);
+exec!(PullsNumberMerge);

--- a/src/repos/post.rs
+++ b/src/repos/post.rs
@@ -1,6 +1,6 @@
 //! Access the Repos portion of the GitHub API
 imports!();
-use client::{PostQueryBuilder, Executor};
+use client::PostQueryBuilder;
 
 new_type!(
     Sha
@@ -11,8 +11,6 @@ new_type!(
 );
 
 from!(
-    @Sha
-        => Executor
     @PostQueryBuilder
         -> Repos = "repos"
     @Repos
@@ -26,9 +24,6 @@ from!(
 );
 
 impl_macro!(
-    @Sha
-        |
-        |-> execute
     @Repos
         |
         |=> owner ->  Owner = username_str
@@ -42,3 +37,5 @@ impl_macro!(
         |
         |=> sha -> Sha = sha_str
 );
+
+exec!(Sha);

--- a/src/users/delete.rs
+++ b/src/users/delete.rs
@@ -1,6 +1,6 @@
 //! Access the Users portion of the GitHub API
 imports!();
-use client::{ DeleteQueryBuilder, Executor };
+use client::DeleteQueryBuilder;
 
 new_type!(
     User
@@ -12,15 +12,12 @@ from!(
        -> User = "user"
     @User
        -> Emails = "emails"
-    @Emails
-       => Executor
 );
 
 impl_macro!(
     @User
         |=> emails -> Emails
         |
-    @Emails
-        |
-        |-> execute
 );
+
+exec!(Emails);

--- a/src/users/get.rs
+++ b/src/users/get.rs
@@ -1,6 +1,6 @@
 //! Access the Users portion of the GitHub API
 imports!();
-use client::{GetQueryBuilder, Executor};
+use client::GetQueryBuilder;
 
 // Declaration of types representing the various items under users
 new_type!(
@@ -37,50 +37,20 @@ from!(
     @GetQueryBuilder
         -> User  = "user"
         -> Users = "users"
-    @Emails
-        => Executor
     @Events
-        => Executor
         -> EventsOrgs = "orgs"
         -> Public =  "public"
     @EventsOrgs
         => EventsOrgsName
-        => Executor
-    @EventsOrgsName
-        => Executor
-    @Followers
-        => Executor
     @Following
         => FollowingUser
-        => Executor
-    @FollowingUser
-        => Executor
-    @Gists
-        => Executor
-    @Issues
-        => Executor
     @Keys
         => KeysId
-        => Executor
-    @KeysId
-        => Executor
-    @Orgs
-        => Executor
-    @Public
-        => Executor
-    @ReceivedEvents
-        => Executor
-    @Subscriptions
-        => Executor
     @Starred
-        => Executor
         => StarredOwner
     @StarredOwner
         => StarredRepo
-    @StarredRepo
-        => Executor
     @User
-        => Executor
         -> Emails = "emails"
         -> Followers = "followers"
         -> Following = "following"
@@ -91,22 +61,13 @@ from!(
         -> Subscriptions = "subscriptions"
         -> Starred = "starred"
     @Users
-        => Executor
         => UsersUsername
-    @UsersOrgs
-        => Executor
-    @UsersKeys
-        => Executor
-    @UsersStarred
-        => Executor
     @UserUsername
-        => Executor
         -> Followers = "followers"
         -> Following = "following"
         -> UsersKeys = "keys"
         -> Repos = "repos"
     @UsersUsername
-        => Executor
         -> Followers = "followers"
         -> Following = "following"
         -> Events = "events"
@@ -117,8 +78,6 @@ from!(
         -> Subscriptions = "subscriptions"
         -> UsersStarred = "starred"
         -> ReceivedEvents = "received_events"
-    @Repos
-        => Executor
 );
 
 // impls of each type
@@ -126,7 +85,6 @@ impl_macro!(
     @Starred
         |
         |=> owner -> StarredOwner = owner_str
-        |-> execute
     @StarredOwner
         |
         |=> repo -> StarredRepo = repo_str
@@ -141,18 +99,15 @@ impl_macro!(
         |=> keys -> Keys
         |=> orgs -> Orgs
         |
-        |-> execute
     @Users
         |
         |=> username -> UsersUsername = username_str
-        |-> execute
     @UserUsername
         |=> followers -> Followers
         |=> following -> Following
         |=> keys -> UsersKeys
         |=> repos -> Repos
         |
-        |-> execute
     @UsersUsername
         |=> events -> Events
         |=> followers -> Followers
@@ -165,69 +120,42 @@ impl_macro!(
         |=> starred -> UsersStarred
         |=> subscriptions -> Subscriptions
         |
-        |-> execute
     @Events
         |=> orgs -> EventsOrgs
         |=> public -> Public
         |
-        |-> execute
     @EventsOrgs
         |
         |=> org -> EventsOrgsName = org_name_str
     @Keys
         |
         |=> id -> KeysId = id_str
-        |-> execute
     @Following
         |
         |=> username -> Following = username_str
-        |-> execute
-    @ReceivedEvents
-        |
-        |-> execute
-    @UsersKeys
-        |
-        |-> execute
-    @Emails
-        |
-        |-> execute
-    @EventsOrgsName
-        |
-        |-> execute
-    @FollowingUser
-        |
-        |-> execute
-    @Gists
-        |
-        |-> execute
-    @Issues
-        |
-        |-> execute
-    @KeysId
-        |
-        |-> execute
-    @Followers
-        |
-        |-> execute
-    @Repos
-        |
-        |-> execute
-    @Subscriptions
-        |
-        |-> execute
-    @StarredRepo
-        |
-        |-> execute
-    @Orgs
-        |
-        |-> execute
-    @Public
-        |
-        |-> execute
-    @UsersOrgs
-        |
-        |-> execute
-    @UsersStarred
-        |
-        |-> execute
 );
+
+exec!(Emails);
+exec!(Events);
+exec!(EventsOrgsName);
+exec!(Followers);
+exec!(Following);
+exec!(FollowingUser);
+exec!(Gists);
+exec!(Issues);
+exec!(Keys);
+exec!(KeysId);
+exec!(Orgs);
+exec!(Public);
+exec!(ReceivedEvents);
+exec!(Repos);
+exec!(Starred);
+exec!(StarredRepo);
+exec!(Subscriptions);
+exec!(User);
+exec!(UserUsername);
+exec!(Users);
+exec!(UsersKeys);
+exec!(UsersOrgs);
+exec!(UsersStarred);
+exec!(UsersUsername);

--- a/src/users/patch.rs
+++ b/src/users/patch.rs
@@ -1,6 +1,6 @@
 //! Access the Users portion of the GitHub API
 imports!();
-use client::{ PatchQueryBuilder, Executor };
+use client::PatchQueryBuilder;
 
 new_type!(
     User
@@ -15,8 +15,6 @@ from!(
         -> Email = "email"
     @Email
         -> Visibility = "visibility"
-    @Visibility
-        => Executor
 );
 
 impl_macro!(
@@ -26,7 +24,6 @@ impl_macro!(
     @Email
         |=> visibility -> Visibility
         |
-    @Visibility
-        |
-        |-> execute
 );
+
+exec!(Visibility);

--- a/src/users/post.rs
+++ b/src/users/post.rs
@@ -1,6 +1,6 @@
 //! Access the Users portion of the GitHub API
 imports!();
-use client::{PostQueryBuilder, Executor};
+use client::PostQueryBuilder;
 
 new_type!(
     User
@@ -12,15 +12,12 @@ from!(
         -> User = "user"
     @User
         -> Emails = "emails"
-    @Emails
-        => Executor
 );
 
 impl_macro!(
     @User
         |=> emails -> Emails
         |
-    @Emails
-        |
-        |-> execute
 );
+
+exec!(Emails);

--- a/src/users/put.rs
+++ b/src/users/put.rs
@@ -1,6 +1,6 @@
 //! Access the Users portion of the GitHub API
 imports!();
-use client::{ PutQueryBuilder, Executor };
+use client::PutQueryBuilder;
 
 new_type!(
     User
@@ -15,8 +15,6 @@ from!(
         -> Following = "following"
     @Following
         => Username
-    @Username
-        => Executor
 );
 
 impl_macro!(
@@ -26,7 +24,6 @@ impl_macro!(
     @Following
         |
         |=> username -> Username = username_str
-    @Username
-        |
-        |-> execute
 );
+
+exec!(Username);

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -1,6 +1,6 @@
 extern crate github_rs as gh;
 extern crate serde_json;
-use gh::client::Github;
+use gh::client::{ Executor, Github };
 use gh::headers::{ etag, rate_limit_remaining };
 use serde_json::Value;
 use std::io::BufReader;


### PR DESCRIPTION
This changes the macro structure so that instead of using from! and
impl_macro! to create the execute() method, it's done by invoking the
exec! macro. This allows all types with the execute() method to
implement the Executor trait. By implementing a trait, it allows
consuming code to easily pass queries around without having to execute
them up front.

@mgattozzi This is a much more invasive change, but I think it simplifies the macros a bit and having the Executor trait is pretty handy. I threw in a new example to show how I'm using the new functionality.