### PR TITLE
Create GitHub GQL subcrate

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,6 +21,8 @@ build: false
 
 test_script:
   - cargo build
+  - cd github-gql-rs
+  - cargo build
 cache:
   - target
   - C:\Users\appveyor\.cargo\registry

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 Cargo.lock
 tests/auth_token
+
+# github-gql-rs
+/github-gql-rs/target
+/github-gql-rs/tests/auth_token

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ rust:
   - nightly
 script:
 - cargo build
+- cd github-gql-rs
+- cargo build

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 | CodeCov   | [![codecov](https://codecov.io/gh/mgattozzi/github-rs/branch/master/graph/badge.svg)](https://codecov.io/gh/mgattozzi/github-rs)      |
 | crates.io | ![crates.io](https://img.shields.io/crates/v/github-rs.svg)
 
-Pure Rust bindings to the Github API
+Pure Rust bindings to the Github V3 API. If you want bindings to the V4 library
+see the [github-graphql-rs](./github-gql-rs) library.
 
 ## Incomplete Bindings
 Please look at the [endpoints](./docs/endpoints.md) docs to see which endpoints
-are currently covered in the API.
+are currently covered in the API. This is for the Github V3 API.
 
 ## Dependencies and Support
 github-rs is intended to work on all tier 1 supported Rust systems:
@@ -46,7 +47,7 @@ Add the following to your `Cargo.toml`
 
 ```toml
 [dependencies]
-github-rs = "0.5"
+github-rs = "0.6"
 ```
 
 Then in your `lib.rs` or `main.rs` file add:

--- a/github-gql-rs/Cargo.toml
+++ b/github-gql-rs/Cargo.toml
@@ -1,16 +1,22 @@
 [package]
+name = "github-gql-rs"
+version = "0.0.1"
 authors = ["Michael Gattozzi <mgattozzi@gmail.com>"]
-description = "Pure Rust bindings to the Github API"
-name = "github-rs"
-version = "0.6.0"
-license = "MIT"
+description = "Pure Rust bindings to the Github V4 API using GraphQL"
+license = "MIT/Apache-2.0"
 repository = "https://github.com/mgattozzi/github-rs.git"
 homepage = "https://github.com/mgattozzi/github-rs"
 documentation = "https://docs.rs/github-rs/"
+readme = "README.md"
+keywords = []
+categories = []
 
 [badges]
 travis-ci = { repository = "mgattozzi/github-rs", branch = "master" }
 appveyor = { repository = "mgattozzi/github-rs", branch = "master", service = "github" }
+
+[lib]
+name = "github_gql"
 
 [dependencies]
 hyper = "0.11"
@@ -23,6 +29,3 @@ serde_json = "1.0"
 
 [dev-dependencies]
 serde_derive = "1.0"
-
-[workspaces]
-members = ["github-gql-rs"]

--- a/github-gql-rs/LICENSE-APACHE
+++ b/github-gql-rs/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 Michael Gattozzi
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/github-gql-rs/LICENSE-MIT
+++ b/github-gql-rs/LICENSE-MIT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Michael Gattozzi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/github-gql-rs/README.md
+++ b/github-gql-rs/README.md
@@ -1,0 +1,110 @@
+# github-gql-rs
+
+## Incomplete Bindings
+Given that this is a bit more free form a full on GraphQL library for client
+queries has not been made. Please refer to the GitHub V4 API docs for queries
+you can make.
+
+## Dependencies and Support
+github-gql-rs is intended to work on all tier 1 supported Rust systems:
+
+- Windows
+- Linux
+- MacOSX
+
+## Minimum Compiler Version
+Due to the use of certain features githubgql--rs requires rustc version 1.18 or
+higher.
+
+## Project Aims
+- Have a robust API where everything is error handled properly to avoid
+  panics of any kind. A library is the base of an application and should
+  be a solid foundation to be built upon
+- Having stability as part of the API. As such effort will be
+  taken to make sure this code compiles on stable Rust, rather than
+  nightly.
+- Ease of use. The complexity should be hidden from those not hacking on
+  the code itself.
+- Documentation of everything so not only is it easy to hack on but
+  finding out how to use the library should be easy to find.
+
+## Getting Started
+Add the following to your `Cargo.toml`
+
+```toml
+[dependencies]
+github-gql-rs = "0.01"
+```
+
+Then in your `lib.rs` or `main.rs` file add:
+
+```rust
+extern crate github_gql;
+use github_gql::client::Github;
+```
+
+Now you can start making queries. Here's a small example to get your user
+information:
+
+```rust
+extern crate github_gql as gh;
+extern crate serde_json;
+use gh::client::Github;
+use gh::query::Query;
+use serde_json::Value;
+
+fn main() {
+    let mut g = Github::new("YOUR API TOKEN GOES HERE").unwrap();
+    let (headers, status, json) = g.query::<Value>(
+        &Query::new_raw("query { viewer { login } }")
+    ).unwrap();
+
+    println!("{}", headers);
+    println!("{}", status);
+    if let Some(json) = json {
+        println!("{}", json);
+    }
+
+    // This will update https://github.com/octocat/Hello-World/issues/349
+    // with a HOORAY emoji!
+    let (headers, status, json) = g.mutation::<Value>(
+        &Mutation::new_raw(
+        "mutation AddReactionToIssue { \
+            addReaction( input: { subjectId: \\\"MDU6SXNzdWUyMzEzOTE1NTE=\\\", content: HOORAY } ) { \
+                reaction { \
+                    content \
+                } \
+                subject { \
+                    id \
+                } \
+            } \
+        }")
+    ).unwrap();
+    println!("{}", headers);
+    println!("{}", status);
+    if let Some(json) = json {
+        println!("{}", json);
+    }
+}
+```
+
+## Hacking on the Library
+- [GitHub API Reference Docs](https://developer.github.com/v4/)
+
+## Contributing
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Licensing
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/github-gql-rs/src/client.rs
+++ b/github-gql-rs/src/client.rs
@@ -1,0 +1,142 @@
+// Tokio/Future Imports
+use tokio_core::reactor::Core;
+use futures::future::ok;
+use futures::{ Stream, Future };
+
+use serde_json;
+// Hyper Imports
+use hyper::{ self, Headers };
+use hyper::client::Client;
+use hyper::StatusCode;
+use hyper_rustls::HttpsConnector;
+
+// Serde Imports
+use serde::de::DeserializeOwned;
+
+// Lib Imports
+use errors::*;
+use query::Query;
+use mutation::Mutation;
+use IntoGithubRequest;
+
+// Std Imports
+use std::rc::Rc;
+use std::cell::RefCell;
+
+/// Struct used to make calls to the Github API.
+pub struct Github {
+    token: String,
+    core: Rc<RefCell<Core>>,
+    client: Rc<Client<HttpsConnector>>,
+}
+
+impl Clone for Github {
+    fn clone(&self) -> Self {
+        Self {
+            token: self.token.clone(),
+            core: self.core.clone(),
+            client: self.client.clone(),
+        }
+    }
+}
+
+impl Github {
+    /// Create a new Github client struct. It takes a type that can convert into
+    /// a `String` (`&str` or `Vec<u8>` for example). As long as the function is
+    /// given a valid API Token your requests will work.
+    pub fn new<T>(token: T) -> Result<Self>
+        where T: ToString
+    {
+        let core = Core::new()?;
+        let handle = core.handle();
+        let client = Client::configure()
+            .connector(HttpsConnector::new(4,&handle))
+            .build(&handle);
+        Ok(Self {
+            token: token.to_string(),
+            core: Rc::new(RefCell::new(core)),
+            client: Rc::new(client),
+        })
+    }
+
+    /// Get the currently set Authorization Token
+    pub fn get_token(&self) -> &str {
+        &self.token
+    }
+
+    /// Change the currently set Authorization Token using a type that can turn
+    /// into an &str. Must be a valid API Token for requests to work.
+    pub fn set_token<T>(&mut self, token: T)
+        where T: ToString {
+        self.token = token.to_string();
+    }
+
+    /// Exposes the inner event loop for those who need
+    /// access to it. The recommended way to safely access
+    /// the core would be
+    ///
+    /// ```text
+    /// let g = Github::new("API KEY");
+    /// let core = g.get_core();
+    /// // Handle the error here.
+    /// let ref mut core_mut = *core.try_borrow_mut()?;
+    /// // Do stuff with the core here. This prevents a runtime failure by
+    /// // having two mutable borrows to the core at the same time.
+    /// ```
+    ///
+    /// This is how other parts of the API are implemented to avoid causing your
+    /// program to crash unexpectedly. While you could borrow without the
+    /// `Result` being handled it's highly recommended you don't unless you know
+    /// there is no other mutable reference to it.
+    pub fn get_core(&self) -> &Rc<RefCell<Core>> {
+        &self.core
+    }
+
+    pub fn query<T>(
+        &mut self,
+        query: &Query) -> Result<(Headers, StatusCode, Option<T>)>
+            where T:DeserializeOwned
+    {
+        self.run(query)
+    }
+
+    pub fn mutation<T>(&mut self, mutation: &Mutation)
+        -> Result<(Headers, StatusCode, Option<T>)>
+        where T:DeserializeOwned
+    {
+        self.run(mutation)
+    }
+
+    fn run<T,I>(&mut self, request: &I) -> Result<(Headers, StatusCode, Option<T>)>
+            where T: DeserializeOwned,
+                  I: IntoGithubRequest,
+    {
+        let mut core_ref = self.core
+            .try_borrow_mut()
+            .chain_err(|| "Unable to get mutable borrow \
+                                    to the event loop")?;
+        let client = &self.client;
+        let work = client
+            .request(request.into_github_req(&self.token)?)
+            .and_then(|res| {
+                let header = res.headers().clone();
+                let status = res.status();
+                res.body().fold(Vec::new(), |mut v, chunk| {
+                    v.extend(&chunk[..]);
+                    ok::<_, hyper::Error>(v)
+                }).map(move |chunks| {
+                    if chunks.is_empty() {
+                        Ok((header, status, None))
+                    } else {
+                        Ok((
+                            header,
+                            status,
+                            Some(serde_json::from_slice(&chunks)
+                                    .chain_err(|| "Failed to parse response body")?)
+                        ))
+                    }
+                })
+            });
+        core_ref.run(work).chain_err(|| "Failed to execute request")?
+    }
+}

--- a/github-gql-rs/src/lib.rs
+++ b/github-gql-rs/src/lib.rs
@@ -1,0 +1,34 @@
+//! Library to used to access the Github API with Rust
+
+#[macro_use]
+extern crate error_chain;
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate futures;
+extern crate tokio_core;
+extern crate serde;
+extern crate serde_json;
+
+pub mod errors {
+    error_chain!{
+        foreign_links {
+            Io(::std::io::Error)
+                #[doc = "`std::io::Error` converted to an error-chain type"];
+            Serde(::serde_json::Error)
+                #[doc = "`serde_json::Error` converted to an error-chain type"];
+            Hyper(::hyper::Error)
+                #[doc = "`hyper::Error` converted to an error-chain type"];
+        }
+    }
+}
+
+pub mod client;
+pub mod query;
+pub mod mutation;
+
+pub use hyper::{Headers, StatusCode};
+
+use errors::Result;
+pub trait IntoGithubRequest {
+    fn into_github_req(&self, token: &str) -> Result<hyper::Request>;
+}

--- a/github-gql-rs/src/mutation.rs
+++ b/github-gql-rs/src/mutation.rs
@@ -1,0 +1,68 @@
+use IntoGithubRequest;
+use hyper::{ Uri, Method, Request };
+use hyper::header::{ Authorization, ContentType, UserAgent };
+use errors::*;
+use std::str::FromStr;
+
+/// Used to mutate information on GitHub
+pub struct Mutation {
+    pub(crate) mutation: String,
+}
+
+impl Mutation {
+    /// Create a new `Mutation`
+    pub fn new() -> Self {
+        Self { mutation: String::new() }
+    }
+    /// Create a new `Mutation` using the given value as the input for the query
+    /// to GitHub. Any other methods used will assume the `String` is empty.
+    /// This is a shortcut for doing:
+    ///
+    /// ```no_test
+    /// let m = Mutation::new();
+    /// m.raw_query("my query which won't work");
+    /// ```
+    ///
+    /// as
+    ///
+    /// ```no_test
+    /// let m = Mutation::new_raw("my query which won't work");
+    /// ```
+    pub fn new_raw<T>(m: T) -> Self
+        where T: ToString
+    {
+        Self { mutation: m.to_string() }
+    }
+
+    /// Whatever you put here becomes your query and replaces anything you might
+    /// have built up before. This assumes you know what you're doing with the
+    /// API so no guarantees can be made here that it will work, only that if
+    /// used this can be used to make a query using the `client::Github` type.
+    pub fn raw_mutation<T>(&mut self, m: T)
+        where T: ToString
+    {
+        self.mutation = m.to_string();
+    }
+}
+
+impl IntoGithubRequest for Mutation {
+    fn into_github_req(&self, token: &str) -> Result<Request> {
+            let mut req = Request::new(
+                Method::Post,
+                Uri::from_str("https://api.github.com/graphql")
+                    .chain_err(|| "Unable to for URL to make the request")?);
+            let mut q = String::from("{ \"query\": \"");
+            q.push_str(&self.mutation);
+            q.push_str("\" }");
+            println!("{}", q);
+            req.set_body(q);
+            let token = String::from("token ") + &token;
+            {
+                let headers = req.headers_mut();
+                headers.set(ContentType::json());
+                headers.set(UserAgent::new(String::from("github-rs")));
+                headers.set(Authorization(token));
+            }
+            Ok(req)
+    }
+}

--- a/github-gql-rs/src/query.rs
+++ b/github-gql-rs/src/query.rs
@@ -1,0 +1,68 @@
+use IntoGithubRequest;
+use hyper::{ Uri, Method, Request };
+use hyper::header::{ Authorization, ContentType, UserAgent };
+use errors::*;
+use std::str::FromStr;
+
+/// Used to query information from the GitHub API to possibly be used in
+/// a `Mutation` or for information to make decisions with how to interact.
+pub struct Query {
+    pub(crate) query: String,
+}
+
+impl Query {
+    /// Create a new `Query`
+    pub fn new() -> Self {
+        Self { query: String::new() }
+    }
+    /// Create a new `Query` using the given value as the input for the query to
+    /// GitHub. Any other methods used will assume the `String` is empty. This
+    /// is a shortcut for doing:
+    ///
+    /// ```no_test
+    /// let q = Query::new();
+    /// q.raw_query("my query which won't work");
+    /// ```
+    ///
+    /// as
+    ///
+    /// ```no_test
+    /// let q = Query::new_raw("my query which won't work");
+    /// ```
+    pub fn new_raw<T>(q: T) -> Self
+        where T: ToString
+    {
+        Self { query: q.to_string() }
+    }
+
+    /// Whatever you put here becomes your query and replaces anything you might
+    /// have built up before. This assumes you know what you're doing with the
+    /// API so no guarantees can be made here that it will work, only that if
+    /// used this can be used to make a query using the `client::Github` type.
+    pub fn raw_query<T>(&mut self, q: T)
+        where T: ToString
+    {
+        self.query = q.to_string();
+    }
+}
+
+impl IntoGithubRequest for Query {
+    fn into_github_req(&self, token: &str) -> Result<Request> {
+            let mut req = Request::new(
+                Method::Post,
+                Uri::from_str("https://api.github.com/graphql")
+                    .chain_err(|| "Unable to for URL to make the request")?);
+            let mut q = String::from("{ \"query\": \"");
+            q.push_str(&self.query);
+            q.push_str("\" }");
+            req.set_body(q);
+            let token = String::from("token ") + &token;
+            {
+                let headers = req.headers_mut();
+                headers.set(ContentType::json());
+                headers.set(UserAgent::new(String::from("github-rs")));
+                headers.set(Authorization(token));
+            }
+            Ok(req)
+    }
+}

--- a/github-gql-rs/tests/users.rs
+++ b/github-gql-rs/tests/users.rs
@@ -1,0 +1,54 @@
+extern crate github_gql as gh;
+extern crate serde_json;
+use gh::client::Github;
+use gh::query::Query;
+use serde_json::Value;
+use std::io::BufReader;
+use std::io::prelude::*;
+use std::fs::File;
+//use gh::mutation::Mutation;
+
+fn auth_token() -> Result<String, std::io::Error> {
+    let file = File::open("tests/auth_token")?;
+    let mut reader = BufReader::new(file);
+    let mut buffer = String::new();
+    let _ = reader.read_line(&mut buffer)?;
+    Ok(buffer)
+}
+
+#[test]
+fn graphql_basic_test() {
+    let mut g = Github::new(&auth_token().unwrap()).unwrap();
+    let (headers, status, json) = g.query::<Value>(
+        &Query::new_raw("query { viewer { login } }")
+    ).unwrap();
+
+    println!("{}", headers);
+    println!("{}", status);
+    if let Some(json) = json {
+        println!("{}", json);
+    }
+}
+
+// #[test]
+// fn add_reaction() {
+//     let mut g = Github::new(&auth_token().unwrap()).unwrap();
+//     let (headers, status, json) = g.mutation::<Value>(
+//         &Mutation::new_raw(
+//         "mutation AddReactionToIssue { \
+//             addReaction( input: { subjectId: \\\"MDU6SXNzdWUyMzEzOTE1NTE=\\\", content: HOORAY } ) { \
+//                 reaction { \
+//                     content \
+//                 } \
+//                 subject { \
+//                     id \
+//                 } \
+//             } \
+//         }")
+//     ).unwrap();
+//     println!("{}", headers);
+//     println!("{}", status);
+//     if let Some(json) = json {
+//         println!("{}", json);
+//     }
+// }


### PR DESCRIPTION
GitHub's V4 API now uses GraphQL. This subcrate provides an interface to
the the V4 API through GraphQL calls while github-rs remains as is to
interface with the V3 API.

Closes: #2 