### PR TITLE
fix (client and macros): fixed clippy warnings

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -38,8 +38,8 @@ impl Clone for Github {
     fn clone(&self) -> Self {
         Self {
             token: self.token.clone(),
-            core: self.core.clone(),
-            client: self.client.clone(),
+            core: Rc::clone(&self.core),
+            client: Rc::clone(&self.client),
         }
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -297,7 +297,7 @@ macro_rules! impl_macro {
     );
 }
 
-/// A variation of impl_macro for the client module that allows partitioning of
+/// A variation of `impl_macro` for the client module that allows partitioning of
 /// types. Create a function with a given name and return type. Used for
 /// creating functions for simple conversions from one type to another, where
 /// the actual conversion code is in the From implementation.


### PR DESCRIPTION
This fix address warnings shown by the clippy linting tool:

- https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#doc_markdown
- https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#clone_on_ref_ptr

I have tested my changes (using an auth_token) and the tests are passing.

ref: https://github.com/rust-lang-nursery/rust-clippy