### PR TITLE
Remove caching on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,6 +23,3 @@ test_script:
   - cargo build
   - cd github-gql-rs
   - cargo build
-cache:
-  - target
-  - C:\Users\appveyor\.cargo\registry


### PR DESCRIPTION
There was a weird EOF issue that kept coming up on appveyor breaking the
build. This changes it to not have it at all.