### PR TITLE
Add non-preview repo GET endpoints, part 1

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -68,12 +68,12 @@ GitHub V3 API
 - [X] /repos/:owner/:repo/commits/:sha/statuses
 - [ ] /repos/:owner/:repo/compare/:base...:head
 - [X] /repos/:owner/:repo/contents/:path
-- [ ] /repos/:owner/:repo/contributors
+- [X] /repos/:owner/:repo/contributors
 - [ ] /repos/:owner/:repo/deployments
 - [ ] /repos/:owner/:repo/deployments/:deployment_id
 - [ ] /repos/:owner/:repo/deployments/:id/statuses
-- [ ] /repos/:owner/:repo/events
-- [ ] /repos/:owner/:repo/forks
+- [X] /repos/:owner/:repo/events
+- [X] /repos/:owner/:repo/forks
 - [ ] /repos/:owner/:repo/git/blobs/:sha
 - [ ] /repos/:owner/:repo/git/commits/:sha
 - [ ] /repos/:owner/:repo/git/refs
@@ -95,11 +95,11 @@ GitHub V3 API
 - [ ] /repos/:owner/:repo/keys/:id
 - [ ] /repos/:owner/:repo/labels
 - [ ] /repos/:owner/:repo/labels/:name
-- [ ] /repos/:owner/:repo/languages
+- [X] /repos/:owner/:repo/languages
 - [ ] /repos/:owner/:repo/milestones
 - [ ] /repos/:owner/:repo/milestones/:number
 - [ ] /repos/:owner/:repo/milestones/:number/labels
-- [ ] /repos/:owner/:repo/notifications
+- [X] /repos/:owner/:repo/notifications
 - [ ] /repos/:owner/:repo/pages/builds
 - [ ] /repos/:owner/:repo/pages/builds/:id
 - [ ] /repos/:owner/:repo/pages/builds/latest
@@ -112,22 +112,22 @@ GitHub V3 API
 - [X] /repos/:owner/:repo/pulls/:number/files
 - [X] /repos/:owner/:repo/pulls/:number/requested_reviewers
 - [X] /repos/:owner/:repo/pulls/:number/merge
-- [ ] /repos/:owner/:repo/readme
+- [X] /repos/:owner/:repo/readme
 - [ ] /repos/:owner/:repo/releases
 - [ ] /repos/:owner/:repo/releases/assets/:id
 - [ ] /repos/:owner/:repo/releases/:id
 - [ ] /repos/:owner/:repo/releases/:id/assets
 - [ ] /repos/:owner/:repo/releases/latest
 - [ ] /repos/:owner/:repo/releases/tags/:tag
-- [ ] /repos/:owner/:repo/stargazers
+- [X] /repos/:owner/:repo/stargazers
 - [ ] /repos/:owner/:repo/stats/code_frequency
 - [ ] /repos/:owner/:repo/stats/commit_activity
 - [ ] /repos/:owner/:repo/stats/contributors
 - [ ] /repos/:owner/:repo/stats/participation
 - [ ] /repos/:owner/:repo/stats/punch_card
-- [ ] /repos/:owner/:repo/subscribers
-- [ ] /repos/:owner/:repo/subscription
-- [ ] /repos/:owner/:repo/tags
+- [X] /repos/:owner/:repo/subscribers
+- [X] /repos/:owner/:repo/subscription
+- [X] /repos/:owner/:repo/tags
 - [ ] /repos/:owner/:repo/teams
 - [ ] /repos/:owner/:repo/traffic/clones
 - [ ] /repos/:owner/:repo/traffic/popular/paths

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -58,10 +58,10 @@ GitHub V3 API
 - [ ] /repos/:owner/:repo/comments
 - [ ] /repos/:owner/:repo/comments/:id
 - [X] /repos/:owner/:repo/commits
-- [ ] /repos/:owner/:repo/commits/:ref
-- [ ] /repos/:owner/:repo/commits/:ref/comments
-- [ ] /repos/:owner/:repo/commits/:ref/status
-- [ ] /repos/:owner/:repo/commits/:ref/statuses
+- [X] /repos/:owner/:repo/commits/:ref
+- [X] /repos/:owner/:repo/commits/:ref/comments
+- [X] /repos/:owner/:repo/commits/:ref/status
+- [X] /repos/:owner/:repo/commits/:ref/statuses
 - [X] /repos/:owner/:repo/commits/:sha
 - [X] /repos/:owner/:repo/commits/:sha/comments
 - [X] /repos/:owner/:repo/commits/:sha/status

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -40,18 +40,18 @@ GitHub V3 API
 - [ ] /orgs/:org/teams
 - [X] /rate_limit
 - [X] /repos/:owner/:repo
-- [ ] /repos/:owner/:repo/:archive_format/:ref
+- [X] /repos/:owner/:repo/:archive_format/:ref
 - [X] /repos/:owner/:repo/assignees
-- [ ] /repos/:owner/:repo/assignees/:assignee
+- [X] /repos/:owner/:repo/assignees/:assignee
 - [X] /repos/:owner/:repo/branches
-- [ ] /repos/:owner/:repo/branches/:branch
-- [ ] /repos/:owner/:repo/branches/:branch/protection
-- [ ] /repos/:owner/:repo/branches/:branch/protection/restrictions
+- [X] /repos/:owner/:repo/branches/:branch
+- [X] /repos/:owner/:repo/branches/:branch/protection
+- [X] /repos/:owner/:repo/branches/:branch/protection/restrictions
 - [ ] /repos/:owner/:repo/branches/:branch/protection/restrictions/teams
-- [ ] /repos/:owner/:repo/branches/:branch/protection/restrictions/users
-- [ ] /repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews
-- [ ] /repos/:owner/:repo/branches/:branch/required_status_checks
-- [ ] /repos/:owner/:repo/branches/:branch/required_status_checks/contexts
+- [X] /repos/:owner/:repo/branches/:branch/protection/restrictions/users
+- [X] /repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews
+- [X] /repos/:owner/:repo/branches/:branch/protection/required_status_checks
+- [X] /repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts
 - [X] /repos/:owner/:repo/collaborators
 - [X] /repos/:owner/:repo/collaborators/:username
 - [X] /repos/:owner/:repo/collaborators/:username/permission

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -9,6 +9,7 @@ new_type!(
     CollaboratorsUsername
     CollaboratorsUsernamePermission
     CommitsSha
+    CommitsRef
     CommitsComments
     CommitsStatus
     CommitsStatuses
@@ -46,8 +47,15 @@ from!(
        -> CommitsStatus = "status"
     @CommitsSha
        -> CommitsStatuses = "statuses"
+    @CommitsRef
+       -> CommitsComments = "comments"
+    @CommitsRef
+       -> CommitsStatus = "status"
+    @CommitsRef
+       -> CommitsStatuses = "statuses"
     @Commits
        => CommitsSha
+       => CommitsRef
 
     @Contents
        => ContentsPath
@@ -112,9 +120,15 @@ impl_macro!(
         |=> status -> CommitsStatus
         |=> statuses -> CommitsStatuses
         |
+    @CommitsRef
+        |=> comments -> CommitsComments
+        |=> status -> CommitsStatus
+        |=> statuses -> CommitsStatuses
+        |
     @Commits
         |
         |=> sha -> CommitsSha = sha_str
+        |=> reference -> CommitsRef = ref_str
     @Contents
         |
         |=> path -> ContentsPath = path_str
@@ -171,6 +185,7 @@ exec!(CollaboratorsUsername);
 exec!(CollaboratorsUsernamePermission);
 exec!(Commits);
 exec!(CommitsSha);
+exec!(CommitsRef);
 exec!(CommitsComments);
 exec!(CommitsStatus);
 exec!(CommitsStatuses);

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -17,13 +17,16 @@ new_type!(
     Contents
     ContentsPath
     ContentsReference
+    Contributors
+    Events
+    Forks
     Issues
     IssuesComments
     IssuesCommentsId
     IssuesNumber
     IssuesNumberComments
-    Repo
-    Repos
+    Languages
+    Notifications
     Owner
     Pulls
     PullsComments
@@ -34,6 +37,13 @@ new_type!(
     PullsNumberFiles
     PullsNumberRequestedReviewers
     PullsNumberMerge
+    Readme
+    Repo
+    Repos
+    Stargazers
+    Subscribers
+    Subscription
+    Tags
 );
 
 from!(
@@ -85,8 +95,28 @@ from!(
     @Repo
        -> Contents = "contents"
     @Repo
+       -> Contributors = "contributors"
+    @Repo
+       -> Events = "events"
+    @Repo
+       -> Forks = "forks"
+    @Repo
+       -> Languages = "languages"
+    @Repo
+       -> Notifications = "notifications"
+    @Repo
        -> Pulls = "pulls"
        -> Issues = "issues"
+    @Repo
+       -> Readme = "readme"
+    @Repo
+       -> Stargazers = "stargazers"
+    @Repo
+       -> Subscribers = "subscribers"
+    @Repo
+       -> Subscription = "subscription"
+    @Repo
+       -> Tags = "tags"
     @Repos
        => Owner
 
@@ -154,8 +184,18 @@ impl_macro!(
         |=> collaborators ->  Collaborators
         |=> commits -> Commits
         |=> contents -> Contents
-        |=> pulls -> Pulls
+        |=> contributors -> Contributors
+        |=> events -> Events
+        |=> forks -> Forks
         |=> issues -> Issues
+        |=> languages -> Languages
+        |=> notifications -> Notifications
+        |=> pulls -> Pulls
+        |=> readme -> Readme
+        |=> stargazers -> Stargazers
+        |=> subscribers -> Subscribers
+        |=> subscription -> Subscription
+        |=> tags -> Tags
         |
     @Repos
         |
@@ -191,12 +231,16 @@ exec!(CommitsStatus);
 exec!(CommitsStatuses);
 exec!(ContentsPath);
 exec!(ContentsReference);
+exec!(Contributors);
+exec!(Events);
+exec!(Forks);
 exec!(Issues);
 exec!(IssuesComments);
 exec!(IssuesCommentsId);
 exec!(IssuesNumber);
 exec!(IssuesNumberComments);
-exec!(Repo);
+exec!(Languages);
+exec!(Notifications);
 exec!(Pulls);
 exec!(PullsComments);
 exec!(PullsCommentsId);
@@ -206,3 +250,9 @@ exec!(PullsNumberCommits);
 exec!(PullsNumberFiles);
 exec!(PullsNumberRequestedReviewers);
 exec!(PullsNumberMerge);
+exec!(Readme);
+exec!(Repo);
+exec!(Stargazers);
+exec!(Subscribers);
+exec!(Subscription);
+exec!(Tags);

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -3,13 +3,22 @@ imports!();
 use client::GetQueryBuilder;
 
 new_type!(
+    ArchiveReference
     Assignees
+    AssigneesUsername
     Branches
+    BranchesName
+    BranchesNameProtection
+    BranchesNameProtectionRestrictions
+    BranchesNameProtectionRestrictionsUsers
+    BranchesNameProtectionRequiredPullRequestReviews
+    BranchesNameProtectionRequiredStatusChecks
+    BranchesNameProtectionRequiredStatusChecksContexts
     Collaborators
     CollaboratorsUsername
     CollaboratorsUsernamePermission
     CommitsSha
-    CommitsRef
+    CommitsReference
     CommitsComments
     CommitsStatus
     CommitsStatuses
@@ -44,9 +53,27 @@ new_type!(
     Subscribers
     Subscription
     Tags
+    Tarball
+    Zipball
 );
 
 from!(
+    @Assignees
+       => AssigneesUsername
+
+    @Branches
+       => BranchesName
+    @BranchesName
+       -> BranchesNameProtection = "protection"
+    @BranchesNameProtection
+       -> BranchesNameProtectionRestrictions = "restrictions"
+       -> BranchesNameProtectionRequiredPullRequestReviews = "required_pull_request_reviews"
+       -> BranchesNameProtectionRequiredStatusChecks = "required_status_checks"
+    @BranchesNameProtectionRestrictions
+       -> BranchesNameProtectionRestrictionsUsers = "users"
+    @BranchesNameProtectionRequiredStatusChecks
+       -> BranchesNameProtectionRequiredStatusChecksContexts = "contexts"
+
     @Collaborators
        => CollaboratorsUsername
     @CollaboratorsUsername
@@ -57,15 +84,15 @@ from!(
        -> CommitsStatus = "status"
     @CommitsSha
        -> CommitsStatuses = "statuses"
-    @CommitsRef
+    @CommitsReference
        -> CommitsComments = "comments"
-    @CommitsRef
+    @CommitsReference
        -> CommitsStatus = "status"
-    @CommitsRef
+    @CommitsReference
        -> CommitsStatuses = "statuses"
     @Commits
        => CommitsSha
-       => CommitsRef
+       => CommitsReference
 
     @Contents
        => ContentsPath
@@ -80,6 +107,24 @@ from!(
        => IssuesCommentsId
     @IssuesNumber
        -> IssuesNumberComments = "comments"
+
+    @Pulls
+       -> PullsComments = "comments"
+    @PullsComments
+       => PullsCommentsId
+    @Pulls
+       => PullsNumber
+    @PullsNumber
+       -> PullsNumberComments = "comments"
+    @PullsNumber
+       -> PullsNumberCommits = "commits"
+    @PullsNumber
+       -> PullsNumberFiles = "files"
+    @PullsNumber
+       -> PullsNumberRequestedReviewers = "requested_reviewers"
+    @PullsNumber
+       -> PullsNumberMerge = "merge"
+
     @GetQueryBuilder
        -> Repos = "repos"
     @Owner
@@ -117,28 +162,39 @@ from!(
        -> Subscription = "subscription"
     @Repo
        -> Tags = "tags"
+    @Repo
+       -> Tarball = "tarball"
+       -> Zipball = "zipball"
     @Repos
        => Owner
 
-    @Pulls
-       -> PullsComments = "comments"
-    @PullsComments
-       => PullsCommentsId
-    @Pulls
-       => PullsNumber
-    @PullsNumber
-       -> PullsNumberComments = "comments"
-    @PullsNumber
-       -> PullsNumberCommits = "commits"
-    @PullsNumber
-       -> PullsNumberFiles = "files"
-    @PullsNumber
-       -> PullsNumberRequestedReviewers = "requested_reviewers"
-    @PullsNumber
-       -> PullsNumberMerge = "merge"
+    @Tarball
+       => ArchiveReference
+    @Zipball
+       => ArchiveReference
 );
 
 impl_macro!(
+    @Assignees
+        |
+        |=> username -> AssigneesUsername = username
+    @Branches
+        |
+        |=> name -> BranchesName = name
+    @BranchesName
+        |=> protection -> BranchesNameProtection
+        |
+    @BranchesNameProtection
+        |=> restrictions -> BranchesNameProtectionRestrictions
+        |=> required_pull_request_reviews -> BranchesNameProtectionRequiredPullRequestReviews
+        |=> required_status_checks -> BranchesNameProtectionRequiredStatusChecks
+        |
+    @BranchesNameProtectionRestrictions
+        |=> users -> BranchesNameProtectionRestrictionsUsers
+        |
+    @BranchesNameProtectionRequiredStatusChecks
+        |=> contexts -> BranchesNameProtectionRequiredStatusChecksContexts
+        |
     @Collaborators
         |
         |=> username -> CollaboratorsUsername = username
@@ -150,7 +206,7 @@ impl_macro!(
         |=> status -> CommitsStatus
         |=> statuses -> CommitsStatuses
         |
-    @CommitsRef
+    @CommitsReference
         |=> comments -> CommitsComments
         |=> status -> CommitsStatus
         |=> statuses -> CommitsStatuses
@@ -158,7 +214,7 @@ impl_macro!(
     @Commits
         |
         |=> sha -> CommitsSha = sha_str
-        |=> reference -> CommitsRef = ref_str
+        |=> reference -> CommitsReference = ref_str
     @Contents
         |
         |=> path -> ContentsPath = path_str
@@ -196,6 +252,8 @@ impl_macro!(
         |=> subscribers -> Subscribers
         |=> subscription -> Subscription
         |=> tags -> Tags
+        |=> tarball -> Tarball
+        |=> zipball -> Zipball
         |
     @Repos
         |
@@ -216,16 +274,31 @@ impl_macro!(
         |=> requested_reviewers -> PullsNumberRequestedReviewers
         |=> merge -> PullsNumberMerge
         |
+    @Tarball
+        |
+        |=> reference -> ArchiveReference = ref_str
+    @Zipball
+        |
+        |=> reference -> ArchiveReference = ref_str
 );
 
+exec!(ArchiveReference);
 exec!(Assignees);
+exec!(AssigneesUsername);
 exec!(Branches);
+exec!(BranchesName);
+exec!(BranchesNameProtection);
+exec!(BranchesNameProtectionRestrictions);
+exec!(BranchesNameProtectionRestrictionsUsers);
+exec!(BranchesNameProtectionRequiredPullRequestReviews);
+exec!(BranchesNameProtectionRequiredStatusChecks);
+exec!(BranchesNameProtectionRequiredStatusChecksContexts);
 exec!(Collaborators);
 exec!(CollaboratorsUsername);
 exec!(CollaboratorsUsernamePermission);
 exec!(Commits);
 exec!(CommitsSha);
-exec!(CommitsRef);
+exec!(CommitsReference);
 exec!(CommitsComments);
 exec!(CommitsStatus);
 exec!(CommitsStatuses);
@@ -256,3 +329,5 @@ exec!(Stargazers);
 exec!(Subscribers);
 exec!(Subscription);
 exec!(Tags);
+exec!(Tarball);
+exec!(Zipball);


### PR DESCRIPTION
To keep this review-able I'll be doing this PR in parts. The first part contains

- commits-by-ref endpoints
- top level leaf endpoints
- branch endpoints

Tracking issue: #94