### PR TITLE
Add non-preview notifications endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 Cargo.lock
-tests/auth_token
+/tests/auth_token
 
 # github-gql-rs
 /github-gql-rs/target

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -20,9 +20,9 @@ GitHub V3 API
 - [ ] /issues
 - [X] /meta
 - [ ] /networks/:owner/:repo/events
-- [ ] /notifications
-- [ ] /notifications/threads/:id
-- [ ] /notifications/threads/:id/subscription
+- [X] /notifications
+- [X] /notifications/threads/:id
+- [X] /notifications/threads/:id/subscription
 - [X] /organizations
 - [X] /orgs/:org
 - [X] /orgs/:org/events
@@ -217,8 +217,8 @@ GitHub V3 API
 
 ## PUT
 - [X] /gists/:id/star
-- [ ] /notifications
-- [ ] /notifications/threads/:id/subscription
+- [X] /notifications
+- [X] /notifications/threads/:id/subscription
 - [ ] /orgs/:org/memberships/:username
 - [ ] /orgs/:org/outside_collaborator/:username
 - [ ] /orgs/:org/public_members/:username
@@ -243,7 +243,7 @@ GitHub V3 API
 - [X] /gists/:id
 - [X] /gists/:id/star
 - [X] /gists/:gist_id/comments/:id
-- [ ] /notifications/threads/:id/subscription
+- [X] /notifications/threads/:id/subscription
 - [ ] /orgs/:org/hooks/:id
 - [ ] /orgs/:org/members/:username
 - [ ] /orgs/:org/memberships/:username
@@ -283,7 +283,7 @@ GitHub V3 API
 ## PATCH
 - [X] /gists/:id
 - [X] /gists/:gist_id/comments/:id
-- [ ] /notifications/threads/:id
+- [X] /notifications/threads/:id
 - [ ] /orgs/:org
 - [ ] /orgs/:org/hooks/:id
 - [ ] /repos/:owner/:repo

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,6 +21,7 @@ use serde_json;
 use users;
 use misc;
 use repos;
+use notifications;
 use errors::*;
 use util::url_join;
 use gists;
@@ -266,6 +267,9 @@ impl <'g> GetQueryBuilder<'g> {
     /// Query the organizations endpoint
     func_client!(organizations, misc::get::Organizations<'g>);
 
+    /// Query the notifications endpoint
+    func_client!(notifications, notifications::get::Notifications<'g>);
+
     /// Add an etag to the headers of the request
     pub fn set_etag(mut self, tag: ETag) -> Self {
         match self.request {
@@ -294,6 +298,7 @@ impl <'g> PutQueryBuilder<'g> {
     func_client!(custom_endpoint, CustomQuery, endpoint_str);
     func_client!(user, users::put::User<'g>);
     func_client!(gists, gists::put::Gists<'g>);
+    func_client!(notifications, notifications::put::Notifications<'g>);
 
     /// Add an etag to the headers of the request
     pub fn set_etag(mut self, tag: ETag) -> Self {
@@ -323,6 +328,7 @@ impl <'g> DeleteQueryBuilder<'g> {
     func_client!(custom_endpoint, CustomQuery, endpoint_str);
     func_client!(user, users::delete::User<'g>);
     func_client!(gists, gists::delete::Gists<'g>);
+    func_client!(notifications, notifications::delete::Notifications<'g>);
 
     /// Add an etag to the headers of the request
     pub fn set_etag(mut self, tag: ETag) -> Self {
@@ -382,6 +388,7 @@ impl <'g> PatchQueryBuilder<'g> {
     func_client!(custom_endpoint, CustomQuery, endpoint_str);
     func_client!(user, users::patch::User<'g>);
     func_client!(gists, gists::patch::Gists<'g>);
+    func_client!(notifications, notifications::patch::Notifications<'g>);
 
     /// Add an etag to the headers of the request
     pub fn set_etag(mut self, tag: ETag) -> Self {

--- a/src/notifications/delete.rs
+++ b/src/notifications/delete.rs
@@ -1,0 +1,36 @@
+//! Access the (notifications)[https://developer.github.com/v3/activity/notifications/]
+//! portion of the GitHub API
+imports!();
+use client::DeleteQueryBuilder;
+
+new_type!(
+    Notifications
+    NotificationsThreads
+    NotificationsThreadsId
+    NotificationsThreadsIdSubscription
+);
+
+from!(
+    @DeleteQueryBuilder
+       -> Notifications = "notifications"
+    @Notifications
+       -> NotificationsThreads = "threads"
+    @NotificationsThreads
+       => NotificationsThreadsId
+    @NotificationsThreadsId
+       -> NotificationsThreadsIdSubscription = "subscription"
+);
+
+impl_macro!(
+    @Notifications
+        |=> threads -> NotificationsThreads
+        |
+    @NotificationsThreads
+       |
+       |=> id -> NotificationsThreadsId = thread_id
+    @NotificationsThreadsId
+       |=> subscription -> NotificationsThreadsIdSubscription
+       |
+);
+
+exec!(NotificationsThreadsIdSubscription);

--- a/src/notifications/get.rs
+++ b/src/notifications/get.rs
@@ -1,0 +1,38 @@
+//! Access the (notifications)[https://developer.github.com/v3/activity/notifications/]
+//! portion of the GitHub API
+imports!();
+use client::GetQueryBuilder;
+
+new_type!(
+    Notifications
+    NotificationsThreads
+    NotificationsThreadsId
+    NotificationsThreadsIdSubscription
+);
+
+from!(
+    @GetQueryBuilder
+       -> Notifications = "notifications"
+    @Notifications
+       -> NotificationsThreads = "threads"
+    @NotificationsThreads
+       => NotificationsThreadsId
+    @NotificationsThreadsId
+       -> NotificationsThreadsIdSubscription = "subscription"
+);
+
+impl_macro!(
+    @Notifications
+        |=> threads -> NotificationsThreads
+        |
+    @NotificationsThreads
+       |
+       |=> id -> NotificationsThreadsId = thread_id
+    @NotificationsThreadsId
+       |=> subscription -> NotificationsThreadsIdSubscription
+       |
+);
+
+exec!(Notifications);
+exec!(NotificationsThreadsId);
+exec!(NotificationsThreadsIdSubscription);

--- a/src/notifications/patch.rs
+++ b/src/notifications/patch.rs
@@ -1,0 +1,30 @@
+//! Access the (notifications)[https://developer.github.com/v3/activity/notifications/]
+//! portion of the GitHub API
+imports!();
+use client::PatchQueryBuilder;
+
+new_type!(
+    Notifications
+    NotificationsThreads
+    NotificationsThreadsId
+);
+
+from!(
+    @PatchQueryBuilder
+       -> Notifications = "notifications"
+    @Notifications
+       -> NotificationsThreads = "threads"
+    @NotificationsThreads
+       => NotificationsThreadsId
+);
+
+impl_macro!(
+    @Notifications
+        |=> threads -> NotificationsThreads
+        |
+    @NotificationsThreads
+       |
+       |=> id -> NotificationsThreadsId = thread_id
+);
+
+exec!(NotificationsThreadsId);

--- a/src/notifications/put.rs
+++ b/src/notifications/put.rs
@@ -1,0 +1,37 @@
+//! Access the (notifications)[https://developer.github.com/v3/activity/notifications/]
+//! portion of the GitHub API
+imports!();
+use client::PutQueryBuilder;
+
+new_type!(
+    Notifications
+    NotificationsThreads
+    NotificationsThreadsId
+    NotificationsThreadsIdSubscription
+);
+
+from!(
+    @PutQueryBuilder
+       -> Notifications = "notifications"
+    @Notifications
+       -> NotificationsThreads = "threads"
+    @NotificationsThreads
+       => NotificationsThreadsId
+    @NotificationsThreadsId
+       -> NotificationsThreadsIdSubscription = "subscription"
+);
+
+impl_macro!(
+    @Notifications
+        |=> threads -> NotificationsThreads
+        |
+    @NotificationsThreads
+       |
+       |=> id -> NotificationsThreadsId = thread_id
+    @NotificationsThreadsId
+       |=> subscription -> NotificationsThreadsIdSubscription
+       |
+);
+
+exec!(Notifications);
+exec!(NotificationsThreadsIdSubscription);

--- a/tests/notifications.rs
+++ b/tests/notifications.rs
@@ -1,0 +1,93 @@
+extern crate github_rs as gh;
+#[macro_use]
+extern crate serde_json;
+use gh::client::Executor;
+use serde_json::Value;
+use gh::StatusCode;
+
+mod testutil;
+
+use testutil::*;
+
+// These tests require you to have notifications on your profile. If you don't have a notification
+// only the first test will be called. The tests won't fail if you don't have any notifications.
+
+#[test]
+fn get_notifications() {
+    let g = setup_github_connection();
+    let (headers, status, json) = g.get()
+        .notifications()
+        .execute::<Value>()
+        .expect(testutil::FAILED_GITHUB_CONNECTION);
+    println!("{}", headers);
+    println!("{}", status);
+    assert_eq!(status, StatusCode::Ok);
+    if let Some(json) = json {
+        if !json.as_array().unwrap().is_empty() {
+                let id = json[0].get("id").unwrap().as_str().unwrap();
+                get_single_thread_of_notifications(id);
+                get_subscriptions_of_single_thread(id);
+                put_subscriptions_for_a_thread(id);
+                put_notifications(id);
+        }
+    }
+}
+
+fn get_single_thread_of_notifications(id: &str) {
+    let g = setup_github_connection();
+    let (headers, status, json) = g.get()
+        .notifications()
+        .threads()
+        .id(id)
+        .execute::<Value>()
+        .expect(testutil::FAILED_GITHUB_CONNECTION);
+    println!("{}", headers);
+    println!("{}", status);
+    assert_eq!(status, StatusCode::Ok);
+    if let Some(json) = json {
+        println!("{}", json);
+    }
+}
+
+fn get_subscriptions_of_single_thread(id: &str) {
+    let g = setup_github_connection();
+    let (headers, status, json) = g.get()
+        .notifications()
+        .threads()
+        .id(id)
+        .subscription()
+        .execute::<Value>()
+        .expect(testutil::FAILED_GITHUB_CONNECTION);
+    println!("{}", headers);
+    println!("{}", status);
+
+        if let Some(json) = json {
+        println!("{}", json);
+    }
+}
+
+fn put_notifications(id: &str) {
+    let g = setup_github_connection();
+    let (headers, status, _) = g.put(json!({"id" : id}))
+        .notifications()
+        .execute::<Value>()
+        .expect(testutil::FAILED_GITHUB_CONNECTION);
+    println!("{}", headers);
+    println!("{}", status);
+    assert_eq!(status, StatusCode::ResetContent);
+
+}
+
+fn put_subscriptions_for_a_thread(id: &str) {
+    let g = setup_github_connection();
+    let (headers, status, _) = g.put(json!({"subscribed": true, "ignored": false}))
+        .notifications()
+        .threads()
+        .id(id)
+        .subscription()
+        .execute::<Value>()
+        .expect(testutil::FAILED_GITHUB_CONNECTION);
+    println!("{}", headers);
+    println!("{}", status);
+    assert_eq!(status, StatusCode::Ok);
+}


### PR DESCRIPTION
Fixes #92 

To avoid conflicts in src/client.rs, this is based on top of my search commits. If you'd prefer me to rebase it onto master instead, that's easy enough.

Also, since there weren't too many endpoints in total, I put everything into one commit. If you think it'd be easier to review by request type (GET - 3 endpoints; PUT - 2 endpoints; DELETE - 1 endpoint; PATCH - 1 endpoint), I can split it up into four separate commits.