### PR TITLE
cargo: update hyper-rustls to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ appveyor = { repository = "mgattozzi/github-rs", branch = "master", service = "g
 
 [dependencies]
 hyper = "0.11"
-hyper-rustls = "0.11"
+hyper-rustls = "0.12"
 error-chain = "0.11"
 tokio-core = "0.1"
 futures = "0.1"


### PR DESCRIPTION
This includes a bump to rustls 0.12.0 which has a fix for recent
compilation issues.