### PR TITLE
Add optional native-tls support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,8 +7,16 @@ environment:
   matrix:
     - TARGET: i686-pc-windows-msvc
       BITS: 32
+      FEATURES: default
     - TARGET: x86_64-pc-windows-msvc
       BITS: 64
+      FEATURES: default
+    - TARGET: i686-pc-windows-msvc
+      BITS: 32
+      FEATURES: rust-native-tls
+    - TARGET: x86_64-pc-windows-msvc
+      BITS: 64
+      FEATURES: rust-native-tls
 install:
   # Install Rust
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/
@@ -20,6 +28,6 @@ install:
 build: false
 
 test_script:
-  - cargo build
+  - cargo build --no-default-features --features "%FEATURES%"
   - cd github-gql-rs
-  - cargo build
+  - cargo build --no-default-features --features "%FEATURES%"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ os:
   - osx
 rust:
   - stable
+env:
+  - FEATURES=default
+  - FEATURES=rust-native-tls
 script:
-- cargo build
+- cargo build --no-default-features --features "$FEATURES"
 - cd github-gql-rs
-- cargo build
+- cargo build --no-default-features --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/github-rs/"
 [features]
 default = ["rustls"]
 rustls = ["hyper-rustls"]
+rust-native-tls = ["native-tls", "hyper-tls"]
 
 [badges]
 travis-ci = { repository = "mgattozzi/github-rs", branch = "master" }
@@ -19,6 +20,8 @@ appveyor = { repository = "mgattozzi/github-rs", branch = "master", service = "g
 [dependencies]
 hyper = "0.11"
 hyper-rustls = { version = "0.12", optional = true }
+hyper-tls = { version = "0.1", optional = true }
+native-tls = { version = "0.1", optional = true }
 error-chain = "0.11"
 tokio-core = "0.1"
 futures = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,17 @@ repository = "https://github.com/mgattozzi/github-rs.git"
 homepage = "https://github.com/mgattozzi/github-rs"
 documentation = "https://docs.rs/github-rs/"
 
+[features]
+default = ["rustls"]
+rustls = ["hyper-rustls"]
+
 [badges]
 travis-ci = { repository = "mgattozzi/github-rs", branch = "master" }
 appveyor = { repository = "mgattozzi/github-rs", branch = "master", service = "github" }
 
 [dependencies]
 hyper = "0.11"
-hyper-rustls = "0.12"
+hyper-rustls = { version = "0.12", optional = true }
 error-chain = "0.11"
 tokio-core = "0.1"
 futures = "0.1"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ github-rs is intended to work on all tier 1 supported Rust systems:
 - Linux
 - MacOSX
 
+github-rs supports [rustls] and [rust-native-tls] for TLS connectivity.
+`rustls` is used by default, but one can toggle support with Cargo features:
+
+```toml
+[dependencies.github-rs]
+version = "0.6"
+default-features = false
+features = ["rust-native-tls"]
+```
+
+Since `rustls` depends on [`ring`][ring] for cryptography, hardware support is
+limited to what `ring` supports, currently ARM and x86 (both 32- and 64-bit).
+If you're compiling for other architectures then you may use the
+`rust-native-tls` feature for maximum portability.
+
+[rustls]: https://github.com/ctz/rustls
+[rust-native-tls]: https://github.com/sfackler/rust-native-tls
+[ring]: https://github.com/briansmith/ring
+
 ## Minimum Compiler Version
 Due to the use of certain features github-rs requires rustc version 1.18 or
 higher.

--- a/github-gql-rs/Cargo.toml
+++ b/github-gql-rs/Cargo.toml
@@ -14,6 +14,7 @@ categories = []
 [features]
 default = ["rustls"]
 rustls = ["hyper-rustls"]
+rust-native-tls = ["native-tls", "hyper-tls"]
 
 [badges]
 travis-ci = { repository = "mgattozzi/github-rs", branch = "master" }
@@ -25,6 +26,8 @@ name = "github_gql"
 [dependencies]
 hyper = "0.11"
 hyper-rustls = { version = "0.11", optional = true }
+hyper-tls = { version = "0.1", optional = true }
+native-tls = { version = "0.1", optional = true }
 error-chain = "0.11"
 tokio-core = "0.1"
 futures = "0.1"

--- a/github-gql-rs/Cargo.toml
+++ b/github-gql-rs/Cargo.toml
@@ -11,6 +11,10 @@ readme = "README.md"
 keywords = []
 categories = []
 
+[features]
+default = ["rustls"]
+rustls = ["hyper-rustls"]
+
 [badges]
 travis-ci = { repository = "mgattozzi/github-rs", branch = "master" }
 appveyor = { repository = "mgattozzi/github-rs", branch = "master", service = "github" }
@@ -20,7 +24,7 @@ name = "github_gql"
 
 [dependencies]
 hyper = "0.11"
-hyper-rustls = "0.11"
+hyper-rustls = { version = "0.11", optional = true }
 error-chain = "0.11"
 tokio-core = "0.1"
 futures = "0.1"

--- a/github-gql-rs/src/client.rs
+++ b/github-gql-rs/src/client.rs
@@ -8,6 +8,7 @@ use serde_json;
 use hyper::{ self, Headers };
 use hyper::client::Client;
 use hyper::StatusCode;
+#[cfg(feature = "rustls")]
 use hyper_rustls::HttpsConnector;
 
 // Serde Imports

--- a/github-gql-rs/src/client.rs
+++ b/github-gql-rs/src/client.rs
@@ -10,6 +10,10 @@ use hyper::client::Client;
 use hyper::StatusCode;
 #[cfg(feature = "rustls")]
 use hyper_rustls::HttpsConnector;
+#[cfg(feature = "rust-native-tls")]
+use hyper_tls;
+#[cfg(feature = "rust-native-tls")]
+type HttpsConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
 
 // Serde Imports
 use serde::de::DeserializeOwned;
@@ -50,8 +54,13 @@ impl Github {
     {
         let core = Core::new()?;
         let handle = core.handle();
+        #[cfg(feature = "rustls")]
         let client = Client::configure()
             .connector(HttpsConnector::new(4,&handle))
+            .build(&handle);
+        #[cfg(feature = "rust-native-tls")]
+        let client = Client::configure()
+            .connector(HttpsConnector::new(4,&handle)?)
             .build(&handle);
         Ok(Self {
             token: token.to_string(),

--- a/github-gql-rs/src/lib.rs
+++ b/github-gql-rs/src/lib.rs
@@ -5,6 +5,10 @@ extern crate error_chain;
 extern crate hyper;
 #[cfg(feature = "rustls")]
 extern crate hyper_rustls;
+#[cfg(feature = "rust-native-tls")]
+extern crate hyper_tls;
+#[cfg(feature = "rust-native-tls")]
+extern crate native_tls;
 extern crate futures;
 extern crate tokio_core;
 extern crate serde;
@@ -19,6 +23,9 @@ pub mod errors {
                 #[doc = "`serde_json::Error` converted to an error-chain type"];
             Hyper(::hyper::Error)
                 #[doc = "`hyper::Error` converted to an error-chain type"];
+            NativeTls(::native_tls::Error)
+                #[cfg(feature = "rust-native-tls")]
+                #[doc = "`native_tls::Error` converted to an error-chain type"];
         }
     }
 }

--- a/github-gql-rs/src/lib.rs
+++ b/github-gql-rs/src/lib.rs
@@ -3,6 +3,7 @@
 #[macro_use]
 extern crate error_chain;
 extern crate hyper;
+#[cfg(feature = "rustls")]
 extern crate hyper_rustls;
 extern crate futures;
 extern crate tokio_core;

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,6 +12,10 @@ use hyper::mime::Mime;
 use hyper::StatusCode;
 #[cfg(feature = "rustls")]
 use hyper_rustls::HttpsConnector;
+#[cfg(feature = "rust-native-tls")]
+use hyper_tls;
+#[cfg(feature = "rust-native-tls")]
+type HttpsConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
 
 // Serde Imports
 use serde::de::DeserializeOwned;
@@ -80,8 +84,13 @@ impl Github {
         where T: ToString {
         let core = Core::new()?;
         let handle = core.handle();
+        #[cfg(feature = "rustls")]
         let client = Client::configure()
             .connector(HttpsConnector::new(4,&handle))
+            .build(&handle);
+        #[cfg(feature = "rust-native-tls")]
+        let client = Client::configure()
+            .connector(HttpsConnector::new(4,&handle)?)
             .build(&handle);
         Ok(Self {
             token: token.to_string(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,6 +10,7 @@ use hyper::header::{ Header, Authorization, Accept, ContentType,
                      ETag, IfNoneMatch, UserAgent, qitem };
 use hyper::mime::Mime;
 use hyper::StatusCode;
+#[cfg(feature = "rustls")]
 use hyper_rustls::HttpsConnector;
 
 // Serde Imports

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,7 @@ error_chain!{
         Hyper(::hyper::Error);
         HyperMimeFromStr(::hyper::mime::FromStrError);
         HyperUri(::hyper::error::UriError);
+        HyperTls(::native_tls::Error) #[cfg(feature = "rust-native-tls")];
         Io(::std::io::Error);
         SerdeJson(::serde_json::Error);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,10 @@ extern crate error_chain;
 extern crate hyper;
 #[cfg(feature = "rustls")]
 extern crate hyper_rustls;
+#[cfg(feature = "native-tls")]
+extern crate hyper_tls;
+#[cfg(feature = "native-tls")]
+extern crate native_tls;
 extern crate futures;
 extern crate tokio_core;
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #[macro_use]
 extern crate error_chain;
 extern crate hyper;
+#[cfg(feature = "rustls")]
 extern crate hyper_rustls;
 extern crate futures;
 extern crate tokio_core;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -323,6 +323,10 @@ macro_rules! imports{
         use tokio_core::reactor::Core;
         #[cfg(feature = "rustls")]
         use hyper_rustls::HttpsConnector;
+        #[cfg(feature = "rust-native-tls")]
+        use hyper_tls;
+        #[cfg(feature = "rust-native-tls")]
+        type HttpsConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
         use hyper::client::Client;
         use hyper::client::Request;
         use hyper::StatusCode;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -321,6 +321,7 @@ macro_rules! func_client{
 macro_rules! imports{
     () => (
         use tokio_core::reactor::Core;
+        #[cfg(feature = "rustls")]
         use hyper_rustls::HttpsConnector;
         use hyper::client::Client;
         use hyper::client::Request;


### PR DESCRIPTION
Adds default feature `rustls`; `native-tls` support is enabled by feature `rust-native-tls`. The feature name is chosen because `native-tls` is already taken by the crate, which must be included in order to generate the necessary `error_chain` `foreign_link`.

Fixes #133.