### PR TITLE
Github endpoint is orgs, not organizations

### DIFF
--- a/src/orgs/get.rs
+++ b/src/orgs/get.rs
@@ -23,7 +23,7 @@ new_type!(
 
 from!(
     @GetQueryBuilder
-        -> Orgs = "organizations"
+        -> Orgs = "orgs"
     @Orgs
         => OrgsOrg
     @OrgsOrg


### PR DESCRIPTION
Not sure if this has changed or if the orgs endpoints has never worked or what, but for me it did not work with `organizations` but it did work with `orgs`.