### PR TITLE
implemented internal escaping

### DIFF
--- a/github-gql-rs/Cargo.toml
+++ b/github-gql-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github-gql-rs"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Michael Gattozzi <mgattozzi@gmail.com>"]
 description = "Pure Rust bindings to the Github V4 API using GraphQL"
 license = "MIT/Apache-2.0"

--- a/github-gql-rs/Cargo.toml
+++ b/github-gql-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github-gql-rs"
-version = "0.0.2"
+version = "0.0.1"
 authors = ["Michael Gattozzi <mgattozzi@gmail.com>"]
 description = "Pure Rust bindings to the Github V4 API using GraphQL"
 license = "MIT/Apache-2.0"

--- a/github-gql-rs/README.md
+++ b/github-gql-rs/README.md
@@ -69,16 +69,16 @@ fn main() {
     // with a HOORAY emoji!
     let (headers, status, json) = g.mutation::<Value>(
         &Mutation::new_raw(
-        "mutation AddReactionToIssue { \
-            addReaction( input: { subjectId: \\\"MDU6SXNzdWUyMzEzOTE1NTE=\\\", content: HOORAY } ) { \
-                reaction { \
-                    content \
-                } \
-                subject { \
-                    id \
-                } \
-            } \
-        }")
+        r#"mutation AddReactionToIssue { 
+            addReaction( input: { subjectId: "MDU6SXNzdWUyMzEzOTE1NTE=", content: HOORAY } ) { 
+                reaction { 
+                    content 
+                } 
+                subject { 
+                    id 
+                } 
+            } 
+        }"#)
     ).unwrap();
     println!("{}", headers);
     println!("{}", status);

--- a/github-gql-rs/src/query.rs
+++ b/github-gql-rs/src/query.rs
@@ -53,7 +53,13 @@ impl IntoGithubRequest for Query {
                 Uri::from_str("https://api.github.com/graphql")
                     .chain_err(|| "Unable to for URL to make the request")?);
             let mut q = String::from("{ \"query\": \"");
-            q.push_str(&self.query);
+
+            //escaping new lines and quotation marks for json
+            let mut escaped = (&self.query).to_string();
+            escaped = escaped.replace("\n", "\\n");
+            escaped = escaped.replace("\"", "\\\"");
+        
+            q.push_str(&escaped);
             q.push_str("\" }");
             req.set_body(q);
             let token = String::from("token ") + &token;

--- a/github-gql-rs/tests/users.rs
+++ b/github-gql-rs/tests/users.rs
@@ -30,6 +30,32 @@ fn graphql_basic_test() {
     }
 }
 
+//testing if escaping json properly
+#[test]
+fn graphql_escaping_test()
+{
+    let q_str = r#"{
+  user(login: "mgattozzi") {
+    login
+  }
+}
+"#;
+
+    let mut g = Github::new(&auth_token().unwrap()).unwrap();
+    let (headers, status, json) = g.query::<Value>(
+        &Query::new_raw(q_str)
+    ).unwrap();
+
+    println!("{}", headers);
+    println!("response status: {}", status);
+    if let Some(ref json) = json {
+        println!("{}", json);
+    }
+    assert_eq!(json.unwrap()["data"]["user"]["login"].as_str().unwrap(),"mgattozzi");
+
+}
+
+
 // #[test]
 // fn add_reaction() {
 //     let mut g = Github::new(&auth_token().unwrap()).unwrap();


### PR DESCRIPTION
Implemented internal escaping for json. Current version needs to think about escaping json manually (quotations, new lines) which is error prone and hard to use. Changing escaping to internal implementation will allow to just paste graphql requests and have necessary characters be implicitly escaped when passed inside json.

It is a breaking change (changed from explicit to implicit escaping) so I upped a version to 0.0.2