### PR TITLE
Add repo references

### DIFF
--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -29,6 +29,7 @@ new_type!(
     Contributors
     Events
     Forks
+    Git
     Issues
     IssuesState
     IssuesComments
@@ -48,6 +49,8 @@ new_type!(
     PullsNumberRequestedReviewers
     PullsNumberMerge
     Readme
+    Reference
+    Refs
     Repo
     Repos
     Stargazers
@@ -100,6 +103,9 @@ from!(
     @ContentsPath
        ?> ContentsReference = "ref"
 
+    @Git
+       -> Refs = "refs"
+
     @Issues
        -> IssuesComments = "comments"
     @Issues
@@ -132,6 +138,8 @@ from!(
        -> Repos = "repos"
     @Owner
        => Repo
+    @Refs
+       -> Reference = "ref"
     @Repo
        -> Assignees = "assignees"
     @Repo
@@ -148,6 +156,8 @@ from!(
        -> Events = "events"
     @Repo
        -> Forks = "forks"
+    @Repo
+       -> Git = "git"
     @Repo
        -> Languages = "languages"
     @Repo
@@ -224,6 +234,9 @@ impl_macro!(
     @ContentsPath
         |
         |?> reference -> ContentsReference = ref_str
+    @Git
+        |
+        |?> refs -> Refs = reference_str
     @Issues
         |=> comments -> IssuesComments
         |
@@ -247,6 +260,7 @@ impl_macro!(
         |=> contributors -> Contributors
         |=> events -> Events
         |=> forks -> Forks
+        |=> git -> Git
         |=> issues -> Issues
         |=> languages -> Languages
         |=> notifications -> Notifications
@@ -329,6 +343,7 @@ exec!(PullsNumberFiles);
 exec!(PullsNumberRequestedReviewers);
 exec!(PullsNumberMerge);
 exec!(Readme);
+exec!(Refs);
 exec!(Repo);
 exec!(Stargazers);
 exec!(Subscribers);


### PR DESCRIPTION
This is a first try to add `git/refs` endpoints to `repo`.

I got `GET /repos/:owner/:repo/git/refs/:ref` working ([doc](https://developer.github.com/v3/git/refs/#get-a-reference)):
```rust
#[test]
fn get_ref() {
    let g = setup_github_connection();
    let (headers, status, json) = g.get()
        .repos()
        .owner("enricostano")
        .repo("stanosas")
        .git()
        .refs("a26c0085d055e4df0972728dd41815746009336f")
        .execute::<Value>()
        .expect(testutil::FAILED_GITHUB_CONNECTION);
    println!("{}", headers);
    println!("{}", status);
    assert_eq!(status, StatusCode::Ok);
```
Now I'm trying to get the `index` endpoint working but I'm not sure how to allow `.refs()` to either receive a parameter (`show` endpoint) or nothing (`index` endpoint).

Any feedback/help? Thanks!