### PR TITLE
Add custom hostname option to support GHE

### DIFF
--- a/github-gql-rs/src/lib.rs
+++ b/github-gql-rs/src/lib.rs
@@ -39,5 +39,5 @@ pub use hyper::{HeaderMap, StatusCode};
 
 use errors::Result;
 pub trait IntoGithubRequest {
-    fn into_github_req(&self, token: &str) -> Result<hyper::Request<hyper::Body>>;
+    fn into_github_req(&self, hostname: &str, token: &str) -> Result<hyper::Request<hyper::Body>>;
 }

--- a/github-gql-rs/src/mutation.rs
+++ b/github-gql-rs/src/mutation.rs
@@ -46,14 +46,14 @@ impl Mutation {
 }
 
 impl IntoGithubRequest for Mutation {
-    fn into_github_req(&self, token: &str) -> Result<Request<hyper::Body>> {
+    fn into_github_req(&self, hostname: &str, token: &str) -> Result<Request<hyper::Body>> {
             let mut q = String::from("{ \"query\": \"");
             q.push_str(&self.mutation);
             q.push_str("\" }");
             println!("{}", q);
             let mut req = Request::builder()
                 .method("POST")
-                .uri("https://api.github.com/graphql")
+                .uri(format!("https://{}/graphql", hostname))
                 .body(q.into())
                 .chain_err(|| "Unable to for URL to make the request")?;
             let token = String::from("token ") + &token;

--- a/github-gql-rs/src/query.rs
+++ b/github-gql-rs/src/query.rs
@@ -46,7 +46,7 @@ impl Query {
 }
 
 impl IntoGithubRequest for Query {
-    fn into_github_req(&self, token: &str) -> Result<Request<hyper::Body>> {
+    fn into_github_req(&self, hostname: &str, token: &str) -> Result<Request<hyper::Body>> {
 
             //escaping new lines and quotation marks for json
             let mut escaped = (&self.query).to_string();
@@ -58,7 +58,7 @@ impl IntoGithubRequest for Query {
             q.push_str("\" }");
             let mut req = Request::builder()
                 .method("POST")
-                .uri("https://api.github.com/graphql")
+                .uri(format!("https://{}/graphql", hostname))
                 .body(q.into())
                 .chain_err(|| "Unable to for URL to make the request")?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,12 +30,14 @@ use util::url_join;
 use gists;
 use orgs;
 
+// Std Imports
 use std::rc::Rc;
 use std::cell::RefCell;
 
 /// Struct used to make calls to the Github API.
 pub struct Github {
     token: String,
+    hostname: String,
     core: Rc<RefCell<Core>>,
     client: Rc<Client<HttpsConnector>>,
 }
@@ -44,6 +46,7 @@ impl Clone for Github {
     fn clone(&self) -> Self {
         Self {
             token: self.token.clone(),
+            hostname: self.hostname.clone(),
             core: Rc::clone(&self.core),
             client: Rc::clone(&self.client),
         }
@@ -90,6 +93,7 @@ impl Github {
             .build(HttpsConnector::new(4,&handle)?);
         Ok(Self {
             token: token.to_string(),
+            hostname: "api.github.com".to_string(),
             core: Rc::new(RefCell::new(core)),
             client: Rc::new(client),
         })
@@ -105,6 +109,17 @@ impl Github {
     pub fn set_token<T>(&mut self, token: T)
         where T: ToString {
         self.token = token.to_string();
+    }
+
+    /// Get the currently set hostname, which defaults to api.github.com.
+    pub fn get_hostname(&self) -> &str {
+        &self.hostname
+    }
+
+    /// Change the hostname that API requests will be made against.
+    pub fn set_hostname<T>(&mut self, hostname: T)
+        where T: ToString {
+        self.hostname = hostname.to_string();
     }
 
     /// Exposes the inner event loop for those who need

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -123,7 +123,7 @@ macro_rules! from {
             fn from(gh: &'g Github) -> Self {
                 use hyper::header::{ ACCEPT, AUTHORIZATION, CONTENT_TYPE, USER_AGENT };
                 let res = Request::builder().method($p)
-                    .uri("https://api.github.com")
+                    .uri(format!("https://{}", &gh.hostname))
                     .body(hyper::Body::empty())
                     .map_err(From::from)
                     .and_then(|req| {


### PR DESCRIPTION
This PR adds a `set_hostname()` method to the Github client that should enable it to be used for GitHub Enterprise as well as public GitHub. The library defaults to public GitHub, so usage remains exactly the same for existing users.